### PR TITLE
Update to CreateAPI 0.2.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,8 +34,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "create-api",
-            url: "https://github.com/CreateAPI/CreateAPI/releases/download/0.1.0/create-api.artifactbundle.zip",
-            checksum: "4e9d1fb023c52e423d57de0928da5d943e3e4c81f6cb903523654867e6372db7"
+            url: "https://github.com/CreateAPI/CreateAPI/releases/download/0.2.0/create-api.artifactbundle.zip",
+            checksum: "6f8a3ce099f07eb2655ccaf6f66d8c9a09b74bb2307781c4adec36609ddac009"
         ),
         .plugin(
             name: "CreateAPI",

--- a/Plugins/CreateAPI/GeneratePlugin.swift
+++ b/Plugins/CreateAPI/GeneratePlugin.swift
@@ -77,7 +77,7 @@ struct Plugin: CommandPlugin {
             .appending(["Sources", "jellyfin-openapi-stable.json"])
 
         let decoder = JSONDecoder()
-        let data = Data(referencing: try NSData(contentsOfFile: filePath.string))
+        let data = try Data(referencing: NSData(contentsOfFile: filePath.string))
         return try decoder.decode(AnyJSON.self, from: data)
     }
 
@@ -186,7 +186,7 @@ struct Plugin: CommandPlugin {
             .directory
             .appending(["Plugins", "CreateAPI", "PatchFiles", "SpecialFeatureType.swift"])
 
-        let sourceData = Data(referencing: try NSData(contentsOfFile: sourceFilePath.string))
+        let sourceData = try Data(referencing: NSData(contentsOfFile: sourceFilePath.string))
 
         let finalFilePath = context
             .package

--- a/Sources/Entities/BaseItemDto.swift
+++ b/Sources/Entities/BaseItemDto.swift
@@ -270,7 +270,7 @@ public struct BaseItemDto: Codable, Hashable, Identifiable {
     public var timerID: String?
     /// Gets or sets the trailer count.
     public var trailerCount: Int?
-    /// Gets or sets the type.
+    /// The base item kind.
     public var type: BaseItemKind?
     /// Gets or sets the user data for this item based on the user it's being requested for.
     public var userData: UserItemDataDto?

--- a/Sources/Entities/ClientCapabilities.swift
+++ b/Sources/Entities/ClientCapabilities.swift
@@ -10,17 +10,20 @@ import Foundation
 
 public struct ClientCapabilities: Codable, Hashable {
     public var appStoreURL: String?
-    /// A MediaBrowser.Model.Dlna.DeviceProfile represents a set of metadata which determines which content a certain device is able to play.
+    /// A MediaBrowser.Model.Dlna.DeviceProfile represents a set of metadata which determines which content a certain device is able to
+    /// play.
     ///
     /// <br />
     ///
     /// Specifically, it defines the supported <see cref="P:MediaBrowser.Model.Dlna.DeviceProfile.ContainerProfiles">containers</see> and
     ///
-    /// <see cref="P:MediaBrowser.Model.Dlna.DeviceProfile.CodecProfiles">codecs</see> (video and/or audio, including codec profiles and levels)
+    /// <see cref="P:MediaBrowser.Model.Dlna.DeviceProfile.CodecProfiles">codecs</see> (video and/or audio, including codec profiles and
+    /// levels)
     ///
     /// the device is able to direct play (without transcoding or remuxing),
     ///
-    /// as well as which <see cref="P:MediaBrowser.Model.Dlna.DeviceProfile.TranscodingProfiles">containers/codecs to transcode to</see> in case it isn't.
+    /// as well as which <see cref="P:MediaBrowser.Model.Dlna.DeviceProfile.TranscodingProfiles">containers/codecs to transcode to</see> in
+    /// case it isn't.
     public var deviceProfile: DeviceProfile?
     public var iconURL: String?
     public var messageCallbackURL: String?

--- a/Sources/Entities/DeviceProfile.swift
+++ b/Sources/Entities/DeviceProfile.swift
@@ -18,7 +18,8 @@ import Foundation
 ///
 /// the device is able to direct play (without transcoding or remuxing),
 ///
-/// as well as which <see cref="P:MediaBrowser.Model.Dlna.DeviceProfile.TranscodingProfiles">containers/codecs to transcode to</see> in case it isn't.
+/// as well as which <see cref="P:MediaBrowser.Model.Dlna.DeviceProfile.TranscodingProfiles">containers/codecs to transcode to</see> in case
+/// it isn't.
 public struct DeviceProfile: Codable, Hashable, Identifiable {
     /// Gets or sets the AlbumArtPn.
     public var albumArtPn: String?

--- a/Sources/Entities/DisplayPreferencesDto.swift
+++ b/Sources/Entities/DisplayPreferencesDto.swift
@@ -26,7 +26,7 @@ public struct DisplayPreferencesDto: Codable, Hashable, Identifiable {
     public var isRememberIndexing: Bool?
     /// Gets or sets a value indicating whether [remember sorting].
     public var isRememberSorting: Bool?
-    /// Gets or sets the scroll direction.
+    /// An enum representing the axis that should be scrolled.
     public var scrollDirection: ScrollDirection?
     /// Gets or sets a value indicating whether to show backdrops on this item.
     public var isShowBackdrop: Bool?
@@ -34,7 +34,7 @@ public struct DisplayPreferencesDto: Codable, Hashable, Identifiable {
     public var isShowSidebar: Bool?
     /// Gets or sets the sort by.
     public var sortBy: String?
-    /// Gets or sets the sort order.
+    /// An enum representing the sorting order.
     public var sortOrder: SortOrder?
     /// Gets or sets the type of the view.
     public var viewType: String?

--- a/Sources/Entities/EncodingOptions.swift
+++ b/Sources/Entities/EncodingOptions.swift
@@ -41,10 +41,10 @@ public struct EncodingOptions: Codable, Hashable {
     public var throttleDelaySeconds: Int?
     public var tonemappingAlgorithm: String?
     public var tonemappingDesat: Double?
+    public var tonemappingMode: String?
     public var tonemappingParam: Double?
     public var tonemappingPeak: Double?
     public var tonemappingRange: String?
-    public var tonemappingThreshold: Double?
     public var transcodingTempPath: String?
     public var vaapiDevice: String?
     public var vppTonemappingBrightness: Double?
@@ -81,10 +81,10 @@ public struct EncodingOptions: Codable, Hashable {
         throttleDelaySeconds: Int? = nil,
         tonemappingAlgorithm: String? = nil,
         tonemappingDesat: Double? = nil,
+        tonemappingMode: String? = nil,
         tonemappingParam: Double? = nil,
         tonemappingPeak: Double? = nil,
         tonemappingRange: String? = nil,
-        tonemappingThreshold: Double? = nil,
         transcodingTempPath: String? = nil,
         vaapiDevice: String? = nil,
         vppTonemappingBrightness: Double? = nil,
@@ -120,10 +120,10 @@ public struct EncodingOptions: Codable, Hashable {
         self.throttleDelaySeconds = throttleDelaySeconds
         self.tonemappingAlgorithm = tonemappingAlgorithm
         self.tonemappingDesat = tonemappingDesat
+        self.tonemappingMode = tonemappingMode
         self.tonemappingParam = tonemappingParam
         self.tonemappingPeak = tonemappingPeak
         self.tonemappingRange = tonemappingRange
-        self.tonemappingThreshold = tonemappingThreshold
         self.transcodingTempPath = transcodingTempPath
         self.vaapiDevice = vaapiDevice
         self.vppTonemappingBrightness = vppTonemappingBrightness
@@ -165,10 +165,10 @@ public struct EncodingOptions: Codable, Hashable {
         self.throttleDelaySeconds = try values.decodeIfPresent(Int.self, forKey: "ThrottleDelaySeconds")
         self.tonemappingAlgorithm = try values.decodeIfPresent(String.self, forKey: "TonemappingAlgorithm")
         self.tonemappingDesat = try values.decodeIfPresent(Double.self, forKey: "TonemappingDesat")
+        self.tonemappingMode = try values.decodeIfPresent(String.self, forKey: "TonemappingMode")
         self.tonemappingParam = try values.decodeIfPresent(Double.self, forKey: "TonemappingParam")
         self.tonemappingPeak = try values.decodeIfPresent(Double.self, forKey: "TonemappingPeak")
         self.tonemappingRange = try values.decodeIfPresent(String.self, forKey: "TonemappingRange")
-        self.tonemappingThreshold = try values.decodeIfPresent(Double.self, forKey: "TonemappingThreshold")
         self.transcodingTempPath = try values.decodeIfPresent(String.self, forKey: "TranscodingTempPath")
         self.vaapiDevice = try values.decodeIfPresent(String.self, forKey: "VaapiDevice")
         self.vppTonemappingBrightness = try values.decodeIfPresent(Double.self, forKey: "VppTonemappingBrightness")
@@ -210,10 +210,10 @@ public struct EncodingOptions: Codable, Hashable {
         try values.encodeIfPresent(throttleDelaySeconds, forKey: "ThrottleDelaySeconds")
         try values.encodeIfPresent(tonemappingAlgorithm, forKey: "TonemappingAlgorithm")
         try values.encodeIfPresent(tonemappingDesat, forKey: "TonemappingDesat")
+        try values.encodeIfPresent(tonemappingMode, forKey: "TonemappingMode")
         try values.encodeIfPresent(tonemappingParam, forKey: "TonemappingParam")
         try values.encodeIfPresent(tonemappingPeak, forKey: "TonemappingPeak")
         try values.encodeIfPresent(tonemappingRange, forKey: "TonemappingRange")
-        try values.encodeIfPresent(tonemappingThreshold, forKey: "TonemappingThreshold")
         try values.encodeIfPresent(transcodingTempPath, forKey: "TranscodingTempPath")
         try values.encodeIfPresent(vaapiDevice, forKey: "VaapiDevice")
         try values.encodeIfPresent(vppTonemappingBrightness, forKey: "VppTonemappingBrightness")

--- a/Sources/Entities/GetProgramsDto.swift
+++ b/Sources/Entities/GetProgramsDto.swift
@@ -26,7 +26,9 @@ public struct GetProgramsDto: Codable, Hashable {
     ///
     /// Optional.
     public var enableUserData: Bool?
-    /// Gets or sets specify additional fields of information to return in the output. This allows multiple, comma delimited. Options: Budget, Chapters, DateCreated, Genres, HomePageUrl, IndexOptions, MediaStreams, Overview, ParentId, Path, People, ProviderIds, PrimaryImageAspectRatio, Revenue, SortName, Studios, Taglines.
+    /// Gets or sets specify additional fields of information to return in the output. This allows multiple, comma delimited. Options:
+    /// Budget, Chapters, DateCreated, Genres, HomePageUrl, IndexOptions, MediaStreams, Overview, ParentId, Path, People, ProviderIds,
+    /// PrimaryImageAspectRatio, Revenue, SortName, Studios, Taglines.
     ///
     /// Optional.
     public var fields: [ItemFields]?

--- a/Sources/Entities/NetworkConfiguration.swift
+++ b/Sources/Entities/NetworkConfiguration.swift
@@ -16,7 +16,8 @@ public struct NetworkConfiguration: Codable, Hashable {
     public var isAutoDiscoveryTracing: Bool?
     /// Gets or sets a value used to specify the URL prefix that your Jellyfin instance can be accessed at.
     public var baseURL: String?
-    /// Gets or sets the password required to access the X.509 certificate data in the file specified by Jellyfin.Networking.Configuration.NetworkConfiguration.CertificatePath.
+    /// Gets or sets the password required to access the X.509 certificate data in the file specified by
+    /// Jellyfin.Networking.Configuration.NetworkConfiguration.CertificatePath.
     public var certificatePassword: String?
     /// Gets or sets the filesystem path of an X.509 certificate to use for SSL.
     public var certificatePath: String?
@@ -46,9 +47,11 @@ public struct NetworkConfiguration: Codable, Hashable {
     public var httpserverPortNumber: Int?
     /// Gets or sets the HTTPS server port number.
     public var httpsPortNumber: Int?
-    /// Gets or sets a value indicating whether address names that match Jellyfin.Networking.Configuration.NetworkConfiguration.VirtualInterfaceNames should be Ignore for the purposes of binding.
+    /// Gets or sets a value indicating whether address names that match
+    /// Jellyfin.Networking.Configuration.NetworkConfiguration.VirtualInterfaceNames should be Ignore for the purposes of binding.
     public var isIgnoreVirtualInterfaces: Bool?
-    /// Gets or sets a value indicating whether <seealso cref="P:Jellyfin.Networking.Configuration.NetworkConfiguration.RemoteIPFilter" /> contains a blacklist or a whitelist. Default is a whitelist.
+    /// Gets or sets a value indicating whether <seealso cref="P:Jellyfin.Networking.Configuration.NetworkConfiguration.RemoteIPFilter" />
+    /// contains a blacklist or a whitelist. Default is a whitelist.
     public var isRemoteIPFilterBlacklist: Bool?
     /// Gets or sets the known proxies. If the proxy is a network, it's added to the KnownNetworks.
     public var knownProxies: [String]?
@@ -64,13 +67,15 @@ public struct NetworkConfiguration: Codable, Hashable {
     ///
     /// Gets or sets PublishedServerUri to advertise for specific subnets.
     public var publishedServerUriBySubnet: [String]?
-    /// Gets or sets the filter for remote IP connectivity. Used in conjuntion with <seealso cref="P:Jellyfin.Networking.Configuration.NetworkConfiguration.IsRemoteIPFilterBlacklist" />.
+    /// Gets or sets the filter for remote IP connectivity. Used in conjuntion with <seealso
+    /// cref="P:Jellyfin.Networking.Configuration.NetworkConfiguration.IsRemoteIPFilterBlacklist" />.
     public var remoteIPFilter: [String]?
     /// Gets or sets a value indicating whether the server should force connections over HTTPS.
     public var requireHTTPS: Bool?
     /// Gets or sets the SSDPTracingFilter
     ///
-    /// Gets or sets a value indicating whether an IP address is to be used to filter the detailed ssdp logs that are being sent to the console/log.
+    /// Gets or sets a value indicating whether an IP address is to be used to filter the detailed ssdp logs that are being sent to the
+    /// console/log.
     ///
     /// If the setting "Emby.Dlna": "Debug" msut be set in logging.default.json for this property to work.
     public var sSDPTracingFilter: String?
@@ -86,7 +91,8 @@ public struct NetworkConfiguration: Codable, Hashable {
     public var uDPSendDelay: Int?
     /// Gets or sets a value indicating whether the http port should be mapped as part of UPnP automatic port forwarding.
     public var isUPnPCreateHTTPPortMap: Bool?
-    /// Gets or sets a value indicating the interfaces that should be ignored. The list can be comma separated. <seealso cref="P:Jellyfin.Networking.Configuration.NetworkConfiguration.IgnoreVirtualInterfaces" />.
+    /// Gets or sets a value indicating the interfaces that should be ignored. The list can be comma separated. <seealso
+    /// cref="P:Jellyfin.Networking.Configuration.NetworkConfiguration.IgnoreVirtualInterfaces" />.
     public var virtualInterfaceNames: String?
 
     public init(

--- a/Sources/Entities/ServerConfiguration.swift
+++ b/Sources/Entities/ServerConfiguration.swift
@@ -51,9 +51,11 @@ public struct ServerConfiguration: Codable, Hashable {
     public var libraryScanFanoutConcurrency: Int?
     /// Gets or sets the number of days we should retain log files.
     public var logFileRetentionDays: Int?
-    /// Gets or sets the remaining minutes of a book that can be played while still saving playstate. If this percentage is crossed playstate will be reset to the beginning and the item will be marked watched.
+    /// Gets or sets the remaining minutes of a book that can be played while still saving playstate. If this percentage is crossed
+    /// playstate will be reset to the beginning and the item will be marked watched.
     public var maxAudiobookResume: Int?
-    /// Gets or sets the maximum percentage of an item that can be played while still saving playstate. If this percentage is crossed playstate will be reset to the beginning and the item will be marked watched.
+    /// Gets or sets the maximum percentage of an item that can be played while still saving playstate. If this percentage is crossed
+    /// playstate will be reset to the beginning and the item will be marked watched.
     public var maxResumePct: Int?
     /// Gets or sets the metadata country code.
     public var metadataCountryCode: String?

--- a/Sources/Entities/SessionInfo.swift
+++ b/Sources/Entities/SessionInfo.swift
@@ -33,9 +33,7 @@ public struct SessionInfo: Codable, Hashable, Identifiable {
     public var lastActivityDate: Date?
     /// Gets or sets the last playback check in.
     public var lastPlaybackCheckIn: Date?
-    /// This is strictly used as a data transfer object from the api layer.
-    ///
-    /// This holds information about a BaseItem in a format that is convenient for the client.
+    /// Gets or sets the now playing item.
     public var nowPlayingItem: BaseItemDto?
     public var nowPlayingQueue: [QueueItem]?
     public var nowPlayingQueueFullItems: [BaseItemDto]?

--- a/Sources/Entities/UserPolicy.swift
+++ b/Sources/Entities/UserPolicy.swift
@@ -52,7 +52,7 @@ public struct UserPolicy: Codable, Hashable {
     public var maxParentalRating: Int?
     public var passwordResetProviderID: String?
     public var remoteClientBitrateLimit: Int?
-    /// Gets or sets a value indicating what SyncPlay features the user can access.
+    /// Enum SyncPlayUserAccessType.
     public var syncPlayAccess: SyncPlayUserAccessType?
 
     public init(

--- a/Sources/JellyfinClient.swift
+++ b/Sources/JellyfinClient.swift
@@ -153,15 +153,6 @@ public final class JellyfinClient {
 
 extension JellyfinClient: APIClientDelegate {
 
-    /// Allows you to modify the request right before it is sent.
-    /// Also injects required Jellyfin headers for every request.
-    ///
-    /// Gets called right before sending the request. If the retries are enabled,
-    /// is called before every attempt.
-    ///
-    /// - parameters:
-    ///   - client: The client that sends the request.
-    ///   - request: The request about to be sent. Can be modified
     public func client(_ client: APIClient, willSendRequest request: inout URLRequest) async throws {
         // Inject required headers
         request.addValue(authHeaders(), forHTTPHeaderField: "Authorization")
@@ -169,17 +160,6 @@ extension JellyfinClient: APIClientDelegate {
         try await delegate?.client(_apiClient, willSendRequest: &request)
     }
 
-    /// Validates response for the given request.
-    ///
-    /// - parameters:
-    ///   - client: The client that sent the request.
-    ///   - response: The response with an invalid status code.
-    ///   - data: Body of the response, if any.
-    ///   - request: Failing request.
-    ///
-    /// - throws: An error to be returned to the user. By default, throws
-    /// ``APIError/unacceptableStatusCode(_:)`` if the code is outside of
-    /// the `200..<300` range.
     public func client(_ client: APIClient, validateResponse response: HTTPURLResponse, data: Data, task: URLSessionTask) throws {
         if let delegate = delegate {
             try delegate.client(_apiClient, validateResponse: response, data: data, task: task)
@@ -190,34 +170,12 @@ extension JellyfinClient: APIClientDelegate {
         }
     }
 
-    /// Gets called after a networking failure. Only one retry attempt is allowed.
-    ///
-    /// - important: This method will only be called for network requests, but not for
-    /// response body decoding failures or failures with creating requests using
-    /// ``client(_:makeURLFor:query:)`` and ``client(_:willSendRequest:)``.
-    ///
-    /// - parameters:
-    ///   - client: The client that sent the request.
-    ///   - task: The failed task.
-    ///   - error: The encountered error.
-    ///   - attempts: The number of already performed attempts.
-    ///
-    /// - returns: Return `true` to retry the request.
     public func client(_ client: APIClient, shouldRetry task: URLSessionTask, error: Error, attempts: Int) async throws -> Bool {
         try await delegate?.client(_apiClient, shouldRetry: task, error: error, attempts: attempts) ?? false
     }
 
-    /// Constructs URL for the given request.
-    ///
-    /// - parameters:
-    ///   - client: The client that sends the request.
-    ///   - url: The URL passed by the client.
-    ///   - request: The request about to be sent.
-    ///
-    /// - returns: The URL for the request. Return `nil` to use the default
-    /// logic used by client.
-    public func client(_ client: APIClient, makeURLFor url: String, query: [(String, String?)]?) throws -> URL? {
-        try delegate?.client(_apiClient, makeURLFor: url, query: query)
+    public func client<T>(_ client: APIClient, makeURLForRequest request: Request<T>) throws -> URL? {
+        try delegate?.client(_apiClient, makeURLForRequest: request)
     }
 }
 
@@ -227,7 +185,8 @@ public extension JellyfinClient {
 
     /// Signs in a user given a username and password. On a successful response `accessToken` is set to the given access token.
     ///
-    /// - Note: Overrides the current access token if one was previously set. Save this token locally or revoke it with `signOut` for proper access token management.
+    /// - Note: Overrides the current access token if one was previously set. Save this token locally or revoke it with `signOut` for proper
+    /// access token management.
     ///
     /// - Parameters:
     ///   - username: username of the user
@@ -250,7 +209,8 @@ public extension JellyfinClient {
 
     /// Signs in a user given a Quick Connect secret.
     ///
-    /// - Note: Overrides the current access token if one was previously set. Save this token locally or revoke it with `signOut` for proper access token management.
+    /// - Note: Overrides the current access token if one was previously set. Save this token locally or revoke it with `signOut` for proper
+    /// access token management.
     ///
     /// - Parameters:
     ///   - quickConnectSecret: current Quick Connect secret

--- a/Sources/Paths/AddListingProviderAPI.swift
+++ b/Sources/Paths/AddListingProviderAPI.swift
@@ -16,7 +16,7 @@ public extension Paths {
         parameters: AddListingProviderParameters? = nil,
         _ body: JellyfinAPI.ListingsProviderInfo? = nil
     ) -> Request<JellyfinAPI.ListingsProviderInfo> {
-        Request(method: "POST", url: "/LiveTv/ListingProviders", query: parameters?.asQuery, body: body, id: "AddListingProvider")
+        Request(path: "/LiveTv/ListingProviders", method: "POST", query: parameters?.asQuery, body: body, id: "AddListingProvider")
     }
 
     struct AddListingProviderParameters {

--- a/Sources/Paths/AddMediaPathAPI.swift
+++ b/Sources/Paths/AddMediaPathAPI.swift
@@ -14,8 +14,8 @@ extension Paths {
     /// Add a media path to a library.
     public static func addMediaPath(isRefreshLibrary: Bool? = nil, _ body: JellyfinAPI.MediaPathDto) -> Request<Void> {
         Request(
+            path: "/Library/VirtualFolders/Paths",
             method: "POST",
-            url: "/Library/VirtualFolders/Paths",
             query: makeAddMediaPathQuery(isRefreshLibrary),
             body: body,
             id: "AddMediaPath"

--- a/Sources/Paths/AddToCollectionAPI.swift
+++ b/Sources/Paths/AddToCollectionAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 extension Paths {
     /// Adds items to a collection.
     public static func addToCollection(collectionID: String, ids: [String]) -> Request<Void> {
-        Request(method: "POST", url: "/Collections/\(collectionID)/Items", query: makeAddToCollectionQuery(ids), id: "AddToCollection")
+        Request(path: "/Collections/\(collectionID)/Items", method: "POST", query: makeAddToCollectionQuery(ids), id: "AddToCollection")
     }
 
     private static func makeAddToCollectionQuery(_ ids: [String]) -> [(String, String?)] {

--- a/Sources/Paths/AddToPlaylistAPI.swift
+++ b/Sources/Paths/AddToPlaylistAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 extension Paths {
     /// Adds items to a playlist.
     public static func addToPlaylist(playlistID: String, ids: [String]? = nil, userID: String? = nil) -> Request<Void> {
-        Request(method: "POST", url: "/Playlists/\(playlistID)/Items", query: makeAddToPlaylistQuery(ids, userID), id: "AddToPlaylist")
+        Request(path: "/Playlists/\(playlistID)/Items", method: "POST", query: makeAddToPlaylistQuery(ids, userID), id: "AddToPlaylist")
     }
 
     private static func makeAddToPlaylistQuery(_ ids: [String]?, _ userID: String?) -> [(String, String?)] {

--- a/Sources/Paths/AddTunerHostAPI.swift
+++ b/Sources/Paths/AddTunerHostAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Adds a tuner host.
     static func addTunerHost(_ body: JellyfinAPI.TunerHostInfo? = nil) -> Request<JellyfinAPI.TunerHostInfo> {
-        Request(method: "POST", url: "/LiveTv/TunerHosts", body: body, id: "AddTunerHost")
+        Request(path: "/LiveTv/TunerHosts", method: "POST", body: body, id: "AddTunerHost")
     }
 }

--- a/Sources/Paths/AddUserToSessionAPI.swift
+++ b/Sources/Paths/AddUserToSessionAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Adds an additional user to a session.
     static func addUserToSession(sessionID: String, userID: String) -> Request<Void> {
-        Request(method: "POST", url: "/Sessions/\(sessionID)/User/\(userID)", id: "AddUserToSession")
+        Request(path: "/Sessions/\(sessionID)/User/\(userID)", method: "POST", id: "AddUserToSession")
     }
 }

--- a/Sources/Paths/AddVirtualFolderAPI.swift
+++ b/Sources/Paths/AddVirtualFolderAPI.swift
@@ -16,7 +16,7 @@ public extension Paths {
         parameters: AddVirtualFolderParameters? = nil,
         _ body: JellyfinAPI.AddVirtualFolderDto? = nil
     ) -> Request<Void> {
-        Request(method: "POST", url: "/Library/VirtualFolders", query: parameters?.asQuery, body: body, id: "AddVirtualFolder")
+        Request(path: "/Library/VirtualFolders", method: "POST", query: parameters?.asQuery, body: body, id: "AddVirtualFolder")
     }
 
     struct AddVirtualFolderParameters {

--- a/Sources/Paths/ApplySearchCriteriaAPI.swift
+++ b/Sources/Paths/ApplySearchCriteriaAPI.swift
@@ -18,8 +18,8 @@ extension Paths {
         _ body: JellyfinAPI.RemoteSearchResult
     ) -> Request<Void> {
         Request(
+            path: "/Items/RemoteSearch/Apply/\(itemID)",
             method: "POST",
-            url: "/Items/RemoteSearch/Apply/\(itemID)",
             query: makeApplySearchCriteriaQuery(isReplaceAllImages),
             body: body,
             id: "ApplySearchCriteria"

--- a/Sources/Paths/AuthenticateUserAPI.swift
+++ b/Sources/Paths/AuthenticateUserAPI.swift
@@ -14,8 +14,8 @@ extension Paths {
     /// Authenticates a user.
     public static func authenticateUser(userID: String, pw: String, password: String? = nil) -> Request<JellyfinAPI.AuthenticationResult> {
         Request(
+            path: "/Users/\(userID)/Authenticate",
             method: "POST",
-            url: "/Users/\(userID)/Authenticate",
             query: makeAuthenticateUserQuery(pw, password),
             id: "AuthenticateUser"
         )

--- a/Sources/Paths/AuthenticateUserByNameAPI.swift
+++ b/Sources/Paths/AuthenticateUserByNameAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Authenticates a user by name.
     static func authenticateUserByName(_ body: JellyfinAPI.AuthenticateUserByName) -> Request<JellyfinAPI.AuthenticationResult> {
-        Request(method: "POST", url: "/Users/AuthenticateByName", body: body, id: "AuthenticateUserByName")
+        Request(path: "/Users/AuthenticateByName", method: "POST", body: body, id: "AuthenticateUserByName")
     }
 }

--- a/Sources/Paths/AuthenticateWithQuickConnectAPI.swift
+++ b/Sources/Paths/AuthenticateWithQuickConnectAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Authenticates a user with quick connect.
     static func authenticateWithQuickConnect(_ body: JellyfinAPI.QuickConnectDto) -> Request<JellyfinAPI.AuthenticationResult> {
-        Request(method: "POST", url: "/Users/AuthenticateWithQuickConnect", body: body, id: "AuthenticateWithQuickConnect")
+        Request(path: "/Users/AuthenticateWithQuickConnect", method: "POST", body: body, id: "AuthenticateWithQuickConnect")
     }
 }

--- a/Sources/Paths/AuthorizeAPI.swift
+++ b/Sources/Paths/AuthorizeAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Authorizes a pending quick connect request.
     static func authorize(code: String) -> Request<Data> {
-        Request(method: "POST", url: "/QuickConnect/Authorize", query: [("code", code)], id: "Authorize")
+        Request(path: "/QuickConnect/Authorize", method: "POST", query: [("code", code)], id: "Authorize")
     }
 }

--- a/Sources/Paths/CancelPackageInstallationAPI.swift
+++ b/Sources/Paths/CancelPackageInstallationAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Cancels a package installation.
     static func cancelPackageInstallation(packageID: String) -> Request<Void> {
-        Request(method: "DELETE", url: "/Packages/Installing/\(packageID)", id: "CancelPackageInstallation")
+        Request(path: "/Packages/Installing/\(packageID)", method: "DELETE", id: "CancelPackageInstallation")
     }
 }

--- a/Sources/Paths/CancelSeriesTimerAPI.swift
+++ b/Sources/Paths/CancelSeriesTimerAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Cancels a live tv series timer.
     static func cancelSeriesTimer(timerID: String) -> Request<Void> {
-        Request(method: "DELETE", url: "/LiveTv/SeriesTimers/\(timerID)", id: "CancelSeriesTimer")
+        Request(path: "/LiveTv/SeriesTimers/\(timerID)", method: "DELETE", id: "CancelSeriesTimer")
     }
 }

--- a/Sources/Paths/CancelTimerAPI.swift
+++ b/Sources/Paths/CancelTimerAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Cancels a live tv timer.
     static func cancelTimer(timerID: String) -> Request<Void> {
-        Request(method: "DELETE", url: "/LiveTv/Timers/\(timerID)", id: "CancelTimer")
+        Request(path: "/LiveTv/Timers/\(timerID)", method: "DELETE", id: "CancelTimer")
     }
 }

--- a/Sources/Paths/CloseLiveStreamAPI.swift
+++ b/Sources/Paths/CloseLiveStreamAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Closes a media source.
     static func closeLiveStream(liveStreamID: String) -> Request<Void> {
-        Request(method: "POST", url: "/LiveStreams/Close", query: [("liveStreamId", liveStreamID)], id: "CloseLiveStream")
+        Request(path: "/LiveStreams/Close", method: "POST", query: [("liveStreamId", liveStreamID)], id: "CloseLiveStream")
     }
 }

--- a/Sources/Paths/CompleteWizardAPI.swift
+++ b/Sources/Paths/CompleteWizardAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Completes the startup wizard.
     static var completeWizard: Request<Void> {
-        Request(method: "POST", url: "/Startup/Complete", id: "CompleteWizard")
+        Request(path: "/Startup/Complete", method: "POST", id: "CompleteWizard")
     }
 }

--- a/Sources/Paths/ConnectAPI.swift
+++ b/Sources/Paths/ConnectAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Attempts to retrieve authentication information.
     static func connect(secret: String) -> Request<JellyfinAPI.QuickConnectResult> {
-        Request(method: "GET", url: "/QuickConnect/Connect", query: [("secret", secret)], id: "Connect")
+        Request(path: "/QuickConnect/Connect", method: "GET", query: [("secret", secret)], id: "Connect")
     }
 }

--- a/Sources/Paths/CreateAdminNotificationAPI.swift
+++ b/Sources/Paths/CreateAdminNotificationAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Sends a notification to all admins.
     static func createAdminNotification(_ body: JellyfinAPI.AdminNotificationDto) -> Request<Void> {
-        Request(method: "POST", url: "/Notifications/Admin", body: body, id: "CreateAdminNotification")
+        Request(path: "/Notifications/Admin", method: "POST", body: body, id: "CreateAdminNotification")
     }
 }

--- a/Sources/Paths/CreateCollectionAPI.swift
+++ b/Sources/Paths/CreateCollectionAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Creates a new collection.
     static func createCollection(parameters: CreateCollectionParameters? = nil) -> Request<JellyfinAPI.CollectionCreationResult> {
-        Request(method: "POST", url: "/Collections", query: parameters?.asQuery, id: "CreateCollection")
+        Request(path: "/Collections", method: "POST", query: parameters?.asQuery, id: "CreateCollection")
     }
 
     struct CreateCollectionParameters {

--- a/Sources/Paths/CreateKeyAPI.swift
+++ b/Sources/Paths/CreateKeyAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Create a new api key.
     static func createKey(app: String) -> Request<Void> {
-        Request(method: "POST", url: "/Auth/Keys", query: [("app", app)], id: "CreateKey")
+        Request(path: "/Auth/Keys", method: "POST", query: [("app", app)], id: "CreateKey")
     }
 }

--- a/Sources/Paths/CreatePlaylistAPI.swift
+++ b/Sources/Paths/CreatePlaylistAPI.swift
@@ -20,7 +20,7 @@ public extension Paths {
         parameters: CreatePlaylistParameters? = nil,
         _ body: JellyfinAPI.CreatePlaylistDto? = nil
     ) -> Request<JellyfinAPI.PlaylistCreationResult> {
-        Request(method: "POST", url: "/Playlists", query: parameters?.asQuery, body: body, id: "CreatePlaylist")
+        Request(path: "/Playlists", method: "POST", query: parameters?.asQuery, body: body, id: "CreatePlaylist")
     }
 
     struct CreatePlaylistParameters {

--- a/Sources/Paths/CreateProfileAPI.swift
+++ b/Sources/Paths/CreateProfileAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Creates a profile.
     static func createProfile(_ body: JellyfinAPI.DeviceProfile? = nil) -> Request<Void> {
-        Request(method: "POST", url: "/Dlna/Profiles", body: body, id: "CreateProfile")
+        Request(path: "/Dlna/Profiles", method: "POST", body: body, id: "CreateProfile")
     }
 }

--- a/Sources/Paths/CreateSeriesTimerAPI.swift
+++ b/Sources/Paths/CreateSeriesTimerAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Creates a live tv series timer.
     static func createSeriesTimer(_ body: JellyfinAPI.SeriesTimerInfoDto? = nil) -> Request<Void> {
-        Request(method: "POST", url: "/LiveTv/SeriesTimers", body: body, id: "CreateSeriesTimer")
+        Request(path: "/LiveTv/SeriesTimers", method: "POST", body: body, id: "CreateSeriesTimer")
     }
 }

--- a/Sources/Paths/CreateTimerAPI.swift
+++ b/Sources/Paths/CreateTimerAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Creates a live tv timer.
     static func createTimer(_ body: JellyfinAPI.TimerInfoDto? = nil) -> Request<Void> {
-        Request(method: "POST", url: "/LiveTv/Timers", body: body, id: "CreateTimer")
+        Request(path: "/LiveTv/Timers", method: "POST", body: body, id: "CreateTimer")
     }
 }

--- a/Sources/Paths/CreateUserByNameAPI.swift
+++ b/Sources/Paths/CreateUserByNameAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Creates a user.
     static func createUserByName(_ body: JellyfinAPI.CreateUserByName) -> Request<JellyfinAPI.UserDto> {
-        Request(method: "POST", url: "/Users/New", body: body, id: "CreateUserByName")
+        Request(path: "/Users/New", method: "POST", body: body, id: "CreateUserByName")
     }
 }

--- a/Sources/Paths/DeleteAlternateSourcesAPI.swift
+++ b/Sources/Paths/DeleteAlternateSourcesAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Removes alternate video sources.
     static func deleteAlternateSources(itemID: String) -> Request<Void> {
-        Request(method: "DELETE", url: "/Videos/\(itemID)/AlternateSources", id: "DeleteAlternateSources")
+        Request(path: "/Videos/\(itemID)/AlternateSources", method: "DELETE", id: "DeleteAlternateSources")
     }
 }

--- a/Sources/Paths/DeleteCustomSplashscreenAPI.swift
+++ b/Sources/Paths/DeleteCustomSplashscreenAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Delete a custom splashscreen.
     static var deleteCustomSplashscreen: Request<Void> {
-        Request(method: "DELETE", url: "/Branding/Splashscreen", id: "DeleteCustomSplashscreen")
+        Request(path: "/Branding/Splashscreen", method: "DELETE", id: "DeleteCustomSplashscreen")
     }
 }

--- a/Sources/Paths/DeleteDeviceAPI.swift
+++ b/Sources/Paths/DeleteDeviceAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Deletes a device.
     static func deleteDevice(id: String) -> Request<Void> {
-        Request(method: "DELETE", url: "/Devices", query: [("id", id)], id: "DeleteDevice")
+        Request(path: "/Devices", method: "DELETE", query: [("id", id)], id: "DeleteDevice")
     }
 }

--- a/Sources/Paths/DeleteItemAPI.swift
+++ b/Sources/Paths/DeleteItemAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Deletes an item from the library and filesystem.
     static func deleteItem(itemID: String) -> Request<Void> {
-        Request(method: "DELETE", url: "/Items/\(itemID)", id: "DeleteItem")
+        Request(path: "/Items/\(itemID)", method: "DELETE", id: "DeleteItem")
     }
 }

--- a/Sources/Paths/DeleteItemImageAPI.swift
+++ b/Sources/Paths/DeleteItemImageAPI.swift
@@ -14,8 +14,8 @@ extension Paths {
     /// Delete an item's image.
     public static func deleteItemImage(itemID: String, imageType: String, imageIndex: Int? = nil) -> Request<Void> {
         Request(
+            path: "/Items/\(itemID)/Images/\(imageType)",
             method: "DELETE",
-            url: "/Items/\(itemID)/Images/\(imageType)",
             query: makeDeleteItemImageQuery(imageIndex),
             id: "DeleteItemImage"
         )

--- a/Sources/Paths/DeleteItemImageByIndexAPI.swift
+++ b/Sources/Paths/DeleteItemImageByIndexAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Delete an item's image.
     static func deleteItemImageByIndex(itemID: String, imageType: String, imageIndex: Int) -> Request<Void> {
-        Request(method: "DELETE", url: "/Items/\(itemID)/Images/\(imageType)/\(imageIndex)", id: "DeleteItemImageByIndex")
+        Request(path: "/Items/\(itemID)/Images/\(imageType)/\(imageIndex)", method: "DELETE", id: "DeleteItemImageByIndex")
     }
 }

--- a/Sources/Paths/DeleteItemsAPI.swift
+++ b/Sources/Paths/DeleteItemsAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 extension Paths {
     /// Deletes items from the library and filesystem.
     public static func deleteItems(ids: [String]? = nil) -> Request<Void> {
-        Request(method: "DELETE", url: "/Items", query: makeDeleteItemsQuery(ids), id: "DeleteItems")
+        Request(path: "/Items", method: "DELETE", query: makeDeleteItemsQuery(ids), id: "DeleteItems")
     }
 
     private static func makeDeleteItemsQuery(_ ids: [String]?) -> [(String, String?)] {

--- a/Sources/Paths/DeleteListingProviderAPI.swift
+++ b/Sources/Paths/DeleteListingProviderAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 extension Paths {
     /// Delete listing provider.
     public static func deleteListingProvider(id: String? = nil) -> Request<Void> {
-        Request(method: "DELETE", url: "/LiveTv/ListingProviders", query: makeDeleteListingProviderQuery(id), id: "DeleteListingProvider")
+        Request(path: "/LiveTv/ListingProviders", method: "DELETE", query: makeDeleteListingProviderQuery(id), id: "DeleteListingProvider")
     }
 
     private static func makeDeleteListingProviderQuery(_ id: String?) -> [(String, String?)] {

--- a/Sources/Paths/DeleteProfileAPI.swift
+++ b/Sources/Paths/DeleteProfileAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Deletes a profile.
     static func deleteProfile(profileID: String) -> Request<Void> {
-        Request(method: "DELETE", url: "/Dlna/Profiles/\(profileID)", id: "DeleteProfile")
+        Request(path: "/Dlna/Profiles/\(profileID)", method: "DELETE", id: "DeleteProfile")
     }
 }

--- a/Sources/Paths/DeleteRecordingAPI.swift
+++ b/Sources/Paths/DeleteRecordingAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Deletes a live tv recording.
     static func deleteRecording(recordingID: String) -> Request<Void> {
-        Request(method: "DELETE", url: "/LiveTv/Recordings/\(recordingID)", id: "DeleteRecording")
+        Request(path: "/LiveTv/Recordings/\(recordingID)", method: "DELETE", id: "DeleteRecording")
     }
 }

--- a/Sources/Paths/DeleteSubtitleAPI.swift
+++ b/Sources/Paths/DeleteSubtitleAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Deletes an external subtitle file.
     static func deleteSubtitle(itemID: String, index: Int) -> Request<Void> {
-        Request(method: "DELETE", url: "/Videos/\(itemID)/Subtitles/\(index)", id: "DeleteSubtitle")
+        Request(path: "/Videos/\(itemID)/Subtitles/\(index)", method: "DELETE", id: "DeleteSubtitle")
     }
 }

--- a/Sources/Paths/DeleteTunerHostAPI.swift
+++ b/Sources/Paths/DeleteTunerHostAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 extension Paths {
     /// Deletes a tuner host.
     public static func deleteTunerHost(id: String? = nil) -> Request<Void> {
-        Request(method: "DELETE", url: "/LiveTv/TunerHosts", query: makeDeleteTunerHostQuery(id), id: "DeleteTunerHost")
+        Request(path: "/LiveTv/TunerHosts", method: "DELETE", query: makeDeleteTunerHostQuery(id), id: "DeleteTunerHost")
     }
 
     private static func makeDeleteTunerHostQuery(_ id: String?) -> [(String, String?)] {

--- a/Sources/Paths/DeleteUserAPI.swift
+++ b/Sources/Paths/DeleteUserAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Deletes a user.
     static func deleteUser(userID: String) -> Request<Void> {
-        Request(method: "DELETE", url: "/Users/\(userID)", id: "DeleteUser")
+        Request(path: "/Users/\(userID)", method: "DELETE", id: "DeleteUser")
     }
 }

--- a/Sources/Paths/DeleteUserImageAPI.swift
+++ b/Sources/Paths/DeleteUserImageAPI.swift
@@ -14,8 +14,8 @@ extension Paths {
     /// Delete the user's image.
     public static func deleteUserImage(userID: String, imageType: String, index: Int? = nil) -> Request<Void> {
         Request(
+            path: "/Users/\(userID)/Images/\(imageType)",
             method: "DELETE",
-            url: "/Users/\(userID)/Images/\(imageType)",
             query: makeDeleteUserImageQuery(index),
             id: "DeleteUserImage"
         )

--- a/Sources/Paths/DeleteUserImageByIndexAPI.swift
+++ b/Sources/Paths/DeleteUserImageByIndexAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Delete the user's image.
     static func deleteUserImageByIndex(userID: String, imageType: String, index: Int) -> Request<Void> {
-        Request(method: "DELETE", url: "/Users/\(userID)/Images/\(imageType)/\(index)", id: "DeleteUserImageByIndex")
+        Request(path: "/Users/\(userID)/Images/\(imageType)/\(index)", method: "DELETE", id: "DeleteUserImageByIndex")
     }
 }

--- a/Sources/Paths/DeleteUserItemRatingAPI.swift
+++ b/Sources/Paths/DeleteUserItemRatingAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Deletes a user's saved personal rating for an item.
     static func deleteUserItemRating(userID: String, itemID: String) -> Request<JellyfinAPI.UserItemDataDto> {
-        Request(method: "DELETE", url: "/Users/\(userID)/Items/\(itemID)/Rating", id: "DeleteUserItemRating")
+        Request(path: "/Users/\(userID)/Items/\(itemID)/Rating", method: "DELETE", id: "DeleteUserItemRating")
     }
 }

--- a/Sources/Paths/DisablePluginAPI.swift
+++ b/Sources/Paths/DisablePluginAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Disable a plugin.
     static func disablePlugin(pluginID: String, version: String) -> Request<Void> {
-        Request(method: "POST", url: "/Plugins/\(pluginID)/\(version)/Disable", id: "DisablePlugin")
+        Request(path: "/Plugins/\(pluginID)/\(version)/Disable", method: "POST", id: "DisablePlugin")
     }
 }

--- a/Sources/Paths/DiscoverTunersAPI.swift
+++ b/Sources/Paths/DiscoverTunersAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 extension Paths {
     /// Discover tuners.
     public static func discoverTuners(isNewDevicesOnly: Bool? = nil) -> Request<[JellyfinAPI.TunerHostInfo]> {
-        Request(method: "GET", url: "/LiveTv/Tuners/Discover", query: makeDiscoverTunersQuery(isNewDevicesOnly), id: "DiscoverTuners")
+        Request(path: "/LiveTv/Tuners/Discover", method: "GET", query: makeDiscoverTunersQuery(isNewDevicesOnly), id: "DiscoverTuners")
     }
 
     private static func makeDiscoverTunersQuery(_ isNewDevicesOnly: Bool?) -> [(String, String?)] {

--- a/Sources/Paths/DiscvoverTunersAPI.swift
+++ b/Sources/Paths/DiscvoverTunersAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 extension Paths {
     /// Discover tuners.
     public static func discvoverTuners(isNewDevicesOnly: Bool? = nil) -> Request<[JellyfinAPI.TunerHostInfo]> {
-        Request(method: "GET", url: "/LiveTv/Tuners/Discvover", query: makeDiscvoverTunersQuery(isNewDevicesOnly), id: "DiscvoverTuners")
+        Request(path: "/LiveTv/Tuners/Discvover", method: "GET", query: makeDiscvoverTunersQuery(isNewDevicesOnly), id: "DiscvoverTuners")
     }
 
     private static func makeDiscvoverTunersQuery(_ isNewDevicesOnly: Bool?) -> [(String, String?)] {

--- a/Sources/Paths/DisplayContentAPI.swift
+++ b/Sources/Paths/DisplayContentAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Instructs a session to browse to an item or view.
     static func displayContent(sessionID: String, parameters: DisplayContentParameters) -> Request<Void> {
-        Request(method: "POST", url: "/Sessions/\(sessionID)/Viewing", query: parameters.asQuery, id: "DisplayContent")
+        Request(path: "/Sessions/\(sessionID)/Viewing", method: "POST", query: parameters.asQuery, id: "DisplayContent")
     }
 
     struct DisplayContentParameters {

--- a/Sources/Paths/DownloadRemoteImageAPI.swift
+++ b/Sources/Paths/DownloadRemoteImageAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Downloads a remote image for an item.
     static func downloadRemoteImage(itemID: String, parameters: DownloadRemoteImageParameters) -> Request<Void> {
-        Request(method: "POST", url: "/Items/\(itemID)/RemoteImages/Download", query: parameters.asQuery, id: "DownloadRemoteImage")
+        Request(path: "/Items/\(itemID)/RemoteImages/Download", method: "POST", query: parameters.asQuery, id: "DownloadRemoteImage")
     }
 
     struct DownloadRemoteImageParameters {

--- a/Sources/Paths/DownloadRemoteSubtitlesAPI.swift
+++ b/Sources/Paths/DownloadRemoteSubtitlesAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Downloads a remote subtitle.
     static func downloadRemoteSubtitles(itemID: String, subtitleID: String) -> Request<Void> {
-        Request(method: "POST", url: "/Items/\(itemID)/RemoteSearch/Subtitles/\(subtitleID)", id: "DownloadRemoteSubtitles")
+        Request(path: "/Items/\(itemID)/RemoteSearch/Subtitles/\(subtitleID)", method: "POST", id: "DownloadRemoteSubtitles")
     }
 }

--- a/Sources/Paths/EnablePluginAPI.swift
+++ b/Sources/Paths/EnablePluginAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Enables a disabled plugin.
     static func enablePlugin(pluginID: String, version: String) -> Request<Void> {
-        Request(method: "POST", url: "/Plugins/\(pluginID)/\(version)/Enable", id: "EnablePlugin")
+        Request(path: "/Plugins/\(pluginID)/\(version)/Enable", method: "POST", id: "EnablePlugin")
     }
 }

--- a/Sources/Paths/ForgotPasswordAPI.swift
+++ b/Sources/Paths/ForgotPasswordAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Initiates the forgot password process for a local user.
     static func forgotPassword(_ body: JellyfinAPI.ForgotPasswordDto) -> Request<JellyfinAPI.ForgotPasswordResult> {
-        Request(method: "POST", url: "/Users/ForgotPassword", body: body, id: "ForgotPassword")
+        Request(path: "/Users/ForgotPassword", method: "POST", body: body, id: "ForgotPassword")
     }
 }

--- a/Sources/Paths/ForgotPasswordPinAPI.swift
+++ b/Sources/Paths/ForgotPasswordPinAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Redeems a forgot password pin.
     static func forgotPasswordPin(_ body: JellyfinAPI.ForgotPasswordPinDto) -> Request<JellyfinAPI.PinRedeemResult> {
-        Request(method: "POST", url: "/Users/ForgotPassword/Pin", body: body, id: "ForgotPasswordPin")
+        Request(path: "/Users/ForgotPassword/Pin", method: "POST", body: body, id: "ForgotPasswordPin")
     }
 }

--- a/Sources/Paths/GetAPI.swift
+++ b/Sources/Paths/GetAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets the search hint result.
     static func get(parameters: GetParameters) -> Request<JellyfinAPI.SearchHintResult> {
-        Request(method: "GET", url: "/Search/Hints", query: parameters.asQuery, id: "Get")
+        Request(path: "/Search/Hints", method: "GET", query: parameters.asQuery, id: "Get")
     }
 
     struct GetParameters {

--- a/Sources/Paths/GetAdditionalPartAPI.swift
+++ b/Sources/Paths/GetAdditionalPartAPI.swift
@@ -13,7 +13,12 @@ import URLQueryEncoder
 extension Paths {
     /// Gets additional parts for a video.
     public static func getAdditionalPart(itemID: String, userID: String? = nil) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/Videos/\(itemID)/AdditionalParts", query: makeGetAdditionalPartQuery(userID), id: "GetAdditionalPart")
+        Request(
+            path: "/Videos/\(itemID)/AdditionalParts",
+            method: "GET",
+            query: makeGetAdditionalPartQuery(userID),
+            id: "GetAdditionalPart"
+        )
     }
 
     private static func makeGetAdditionalPartQuery(_ userID: String?) -> [(String, String?)] {

--- a/Sources/Paths/GetAlbumArtistsAPI.swift
+++ b/Sources/Paths/GetAlbumArtistsAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets all album artists from a given item, folder, or the entire library.
     static func getAlbumArtists(parameters: GetAlbumArtistsParameters? = nil) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/Artists/AlbumArtists", query: parameters?.asQuery, id: "GetAlbumArtists")
+        Request(path: "/Artists/AlbumArtists", method: "GET", query: parameters?.asQuery, id: "GetAlbumArtists")
     }
 
     struct GetAlbumArtistsParameters {

--- a/Sources/Paths/GetAllChannelFeaturesAPI.swift
+++ b/Sources/Paths/GetAllChannelFeaturesAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Get all channel features.
     static var getAllChannelFeatures: Request<[JellyfinAPI.ChannelFeatures]> {
-        Request(method: "GET", url: "/Channels/Features", id: "GetAllChannelFeatures")
+        Request(path: "/Channels/Features", method: "GET", id: "GetAllChannelFeatures")
     }
 }

--- a/Sources/Paths/GetAncestorsAPI.swift
+++ b/Sources/Paths/GetAncestorsAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 extension Paths {
     /// Gets all parents of an item.
     public static func getAncestors(itemID: String, userID: String? = nil) -> Request<[JellyfinAPI.BaseItemDto]> {
-        Request(method: "GET", url: "/Items/\(itemID)/Ancestors", query: makeGetAncestorsQuery(userID), id: "GetAncestors")
+        Request(path: "/Items/\(itemID)/Ancestors", method: "GET", query: makeGetAncestorsQuery(userID), id: "GetAncestors")
     }
 
     private static func makeGetAncestorsQuery(_ userID: String?) -> [(String, String?)] {

--- a/Sources/Paths/GetArtistByNameAPI.swift
+++ b/Sources/Paths/GetArtistByNameAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 extension Paths {
     /// Gets an artist by name.
     public static func getArtistByName(name: String, userID: String? = nil) -> Request<JellyfinAPI.BaseItemDto> {
-        Request(method: "GET", url: "/Artists/\(name)", query: makeGetArtistByNameQuery(userID), id: "GetArtistByName")
+        Request(path: "/Artists/\(name)", method: "GET", query: makeGetArtistByNameQuery(userID), id: "GetArtistByName")
     }
 
     private static func makeGetArtistByNameQuery(_ userID: String?) -> [(String, String?)] {

--- a/Sources/Paths/GetArtistImageAPI.swift
+++ b/Sources/Paths/GetArtistImageAPI.swift
@@ -18,7 +18,7 @@ public extension Paths {
         imageIndex: Int,
         parameters: GetArtistImageParameters? = nil
     ) -> Request<Data> {
-        Request(method: "GET", url: "/Artists/\(name)/Images/\(imageType)/\(imageIndex)", query: parameters?.asQuery, id: "GetArtistImage")
+        Request(path: "/Artists/\(name)/Images/\(imageType)/\(imageIndex)", method: "GET", query: parameters?.asQuery, id: "GetArtistImage")
     }
 
     struct GetArtistImageParameters {

--- a/Sources/Paths/GetArtistsAPI.swift
+++ b/Sources/Paths/GetArtistsAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets all artists from a given item, folder, or the entire library.
     static func getArtists(parameters: GetArtistsParameters? = nil) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/Artists", query: parameters?.asQuery, id: "GetArtists")
+        Request(path: "/Artists", method: "GET", query: parameters?.asQuery, id: "GetArtists")
     }
 
     struct GetArtistsParameters {

--- a/Sources/Paths/GetAttachmentAPI.swift
+++ b/Sources/Paths/GetAttachmentAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Get video attachment.
     static func getAttachment(videoID: String, mediaSourceID: String, index: Int) -> Request<Data> {
-        Request(method: "GET", url: "/Videos/\(videoID)/\(mediaSourceID)/Attachments/\(index)", id: "GetAttachment")
+        Request(path: "/Videos/\(videoID)/\(mediaSourceID)/Attachments/\(index)", method: "GET", id: "GetAttachment")
     }
 }

--- a/Sources/Paths/GetAudioStreamAPI.swift
+++ b/Sources/Paths/GetAudioStreamAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets an audio stream.
     static func getAudioStream(itemID: String, parameters: GetAudioStreamParameters? = nil) -> Request<Data> {
-        Request(method: "GET", url: "/Audio/\(itemID)/stream", query: parameters?.asQuery, id: "GetAudioStream")
+        Request(path: "/Audio/\(itemID)/stream", method: "GET", query: parameters?.asQuery, id: "GetAudioStream")
     }
 
     struct GetAudioStreamParameters {

--- a/Sources/Paths/GetAudioStreamByContainerAPI.swift
+++ b/Sources/Paths/GetAudioStreamByContainerAPI.swift
@@ -17,7 +17,7 @@ public extension Paths {
         container: String,
         parameters: GetAudioStreamByContainerParameters? = nil
     ) -> Request<Data> {
-        Request(method: "GET", url: "/Audio/\(itemID)/stream.\(container)", query: parameters?.asQuery, id: "GetAudioStreamByContainer")
+        Request(path: "/Audio/\(itemID)/stream.\(container)", method: "GET", query: parameters?.asQuery, id: "GetAudioStreamByContainer")
     }
 
     struct GetAudioStreamByContainerParameters {

--- a/Sources/Paths/GetAuthProvidersAPI.swift
+++ b/Sources/Paths/GetAuthProvidersAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Get all auth providers.
     static var getAuthProviders: Request<[JellyfinAPI.NameIDPair]> {
-        Request(method: "GET", url: "/Auth/Providers", id: "GetAuthProviders")
+        Request(path: "/Auth/Providers", method: "GET", id: "GetAuthProviders")
     }
 }

--- a/Sources/Paths/GetBitrateTestBytesAPI.swift
+++ b/Sources/Paths/GetBitrateTestBytesAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 extension Paths {
     /// Tests the network with a request with the size of the bitrate.
     public static func getBitrateTestBytes(size: Int? = nil) -> Request<Data> {
-        Request(method: "GET", url: "/Playback/BitrateTest", query: makeGetBitrateTestBytesQuery(size), id: "GetBitrateTestBytes")
+        Request(path: "/Playback/BitrateTest", method: "GET", query: makeGetBitrateTestBytesQuery(size), id: "GetBitrateTestBytes")
     }
 
     private static func makeGetBitrateTestBytesQuery(_ size: Int?) -> [(String, String?)] {

--- a/Sources/Paths/GetBookRemoteSearchResultsAPI.swift
+++ b/Sources/Paths/GetBookRemoteSearchResultsAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Get book remote search.
     static func getBookRemoteSearchResults(_ body: JellyfinAPI.BookInfoRemoteSearchQuery) -> Request<[JellyfinAPI.RemoteSearchResult]> {
-        Request(method: "POST", url: "/Items/RemoteSearch/Book", body: body, id: "GetBookRemoteSearchResults")
+        Request(path: "/Items/RemoteSearch/Book", method: "POST", body: body, id: "GetBookRemoteSearchResults")
     }
 }

--- a/Sources/Paths/GetBoxSetRemoteSearchResultsAPI.swift
+++ b/Sources/Paths/GetBoxSetRemoteSearchResultsAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Get box set remote search.
     static func getBoxSetRemoteSearchResults(_ body: JellyfinAPI.BoxSetInfoRemoteSearchQuery) -> Request<[JellyfinAPI.RemoteSearchResult]> {
-        Request(method: "POST", url: "/Items/RemoteSearch/BoxSet", body: body, id: "GetBoxSetRemoteSearchResults")
+        Request(path: "/Items/RemoteSearch/BoxSet", method: "POST", body: body, id: "GetBoxSetRemoteSearchResults")
     }
 }

--- a/Sources/Paths/GetBrandingCss2API.swift
+++ b/Sources/Paths/GetBrandingCss2API.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets branding css.
     static var getBrandingCss2: Request<String> {
-        Request(method: "GET", url: "/Branding/Css.css", id: "GetBrandingCss_2")
+        Request(path: "/Branding/Css.css", method: "GET", id: "GetBrandingCss_2")
     }
 }

--- a/Sources/Paths/GetBrandingCssAPI.swift
+++ b/Sources/Paths/GetBrandingCssAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets branding css.
     static var getBrandingCss: Request<String> {
-        Request(method: "GET", url: "/Branding/Css", id: "GetBrandingCss")
+        Request(path: "/Branding/Css", method: "GET", id: "GetBrandingCss")
     }
 }

--- a/Sources/Paths/GetBrandingOptionsAPI.swift
+++ b/Sources/Paths/GetBrandingOptionsAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets branding configuration.
     static var getBrandingOptions: Request<JellyfinAPI.BrandingOptions> {
-        Request(method: "GET", url: "/Branding/Configuration", id: "GetBrandingOptions")
+        Request(path: "/Branding/Configuration", method: "GET", id: "GetBrandingOptions")
     }
 }

--- a/Sources/Paths/GetChannelAPI.swift
+++ b/Sources/Paths/GetChannelAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 extension Paths {
     /// Gets a live tv channel.
     public static func getChannel(channelID: String, userID: String? = nil) -> Request<JellyfinAPI.BaseItemDto> {
-        Request(method: "GET", url: "/LiveTv/Channels/\(channelID)", query: makeGetChannelQuery(userID), id: "GetChannel")
+        Request(path: "/LiveTv/Channels/\(channelID)", method: "GET", query: makeGetChannelQuery(userID), id: "GetChannel")
     }
 
     private static func makeGetChannelQuery(_ userID: String?) -> [(String, String?)] {

--- a/Sources/Paths/GetChannelFeaturesAPI.swift
+++ b/Sources/Paths/GetChannelFeaturesAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Get channel features.
     static func getChannelFeatures(channelID: String) -> Request<JellyfinAPI.ChannelFeatures> {
-        Request(method: "GET", url: "/Channels/\(channelID)/Features", id: "GetChannelFeatures")
+        Request(path: "/Channels/\(channelID)/Features", method: "GET", id: "GetChannelFeatures")
     }
 }

--- a/Sources/Paths/GetChannelItemsAPI.swift
+++ b/Sources/Paths/GetChannelItemsAPI.swift
@@ -16,7 +16,7 @@ public extension Paths {
         channelID: String,
         parameters: GetChannelItemsParameters? = nil
     ) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/Channels/\(channelID)/Items", query: parameters?.asQuery, id: "GetChannelItems")
+        Request(path: "/Channels/\(channelID)/Items", method: "GET", query: parameters?.asQuery, id: "GetChannelItems")
     }
 
     struct GetChannelItemsParameters {

--- a/Sources/Paths/GetChannelMappingOptionsAPI.swift
+++ b/Sources/Paths/GetChannelMappingOptionsAPI.swift
@@ -14,8 +14,8 @@ extension Paths {
     /// Get channel mapping options.
     public static func getChannelMappingOptions(providerID: String? = nil) -> Request<JellyfinAPI.ChannelMappingOptionsDto> {
         Request(
+            path: "/LiveTv/ChannelMappingOptions",
             method: "GET",
-            url: "/LiveTv/ChannelMappingOptions",
             query: makeGetChannelMappingOptionsQuery(providerID),
             id: "GetChannelMappingOptions"
         )

--- a/Sources/Paths/GetChannelsAPI.swift
+++ b/Sources/Paths/GetChannelsAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets available channels.
     static func getChannels(parameters: GetChannelsParameters? = nil) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/Channels", query: parameters?.asQuery, id: "GetChannels")
+        Request(path: "/Channels", method: "GET", query: parameters?.asQuery, id: "GetChannels")
     }
 
     struct GetChannelsParameters {

--- a/Sources/Paths/GetConfigurationAPI.swift
+++ b/Sources/Paths/GetConfigurationAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets application configuration.
     static var getConfiguration: Request<JellyfinAPI.ServerConfiguration> {
-        Request(method: "GET", url: "/System/Configuration", id: "GetConfiguration")
+        Request(path: "/System/Configuration", method: "GET", id: "GetConfiguration")
     }
 }

--- a/Sources/Paths/GetConfigurationPagesAPI.swift
+++ b/Sources/Paths/GetConfigurationPagesAPI.swift
@@ -14,8 +14,8 @@ extension Paths {
     /// Gets the configuration pages.
     public static func getConfigurationPages(enableInMainMenu: Bool? = nil) -> Request<[JellyfinAPI.ConfigurationPageInfo]> {
         Request(
+            path: "/web/ConfigurationPages",
             method: "GET",
-            url: "/web/ConfigurationPages",
             query: makeGetConfigurationPagesQuery(enableInMainMenu),
             id: "GetConfigurationPages"
         )

--- a/Sources/Paths/GetConnectionManager2API.swift
+++ b/Sources/Paths/GetConnectionManager2API.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets Dlna media receiver registrar xml.
     static func getConnectionManager2(serverID: String) -> Request<String> {
-        Request(method: "GET", url: "/Dlna/\(serverID)/ConnectionManager/ConnectionManager", id: "GetConnectionManager_2")
+        Request(path: "/Dlna/\(serverID)/ConnectionManager/ConnectionManager", method: "GET", id: "GetConnectionManager_2")
     }
 }

--- a/Sources/Paths/GetConnectionManager3API.swift
+++ b/Sources/Paths/GetConnectionManager3API.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets Dlna media receiver registrar xml.
     static func getConnectionManager3(serverID: String) -> Request<String> {
-        Request(method: "GET", url: "/Dlna/\(serverID)/ConnectionManager/ConnectionManager.xml", id: "GetConnectionManager_3")
+        Request(path: "/Dlna/\(serverID)/ConnectionManager/ConnectionManager.xml", method: "GET", id: "GetConnectionManager_3")
     }
 }

--- a/Sources/Paths/GetConnectionManagerAPI.swift
+++ b/Sources/Paths/GetConnectionManagerAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets Dlna media receiver registrar xml.
     static func getConnectionManager(serverID: String) -> Request<String> {
-        Request(method: "GET", url: "/Dlna/\(serverID)/ConnectionManager", id: "GetConnectionManager")
+        Request(path: "/Dlna/\(serverID)/ConnectionManager", method: "GET", id: "GetConnectionManager")
     }
 }

--- a/Sources/Paths/GetContentDirectory2API.swift
+++ b/Sources/Paths/GetContentDirectory2API.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets Dlna content directory xml.
     static func getContentDirectory2(serverID: String) -> Request<String> {
-        Request(method: "GET", url: "/Dlna/\(serverID)/ContentDirectory/ContentDirectory", id: "GetContentDirectory_2")
+        Request(path: "/Dlna/\(serverID)/ContentDirectory/ContentDirectory", method: "GET", id: "GetContentDirectory_2")
     }
 }

--- a/Sources/Paths/GetContentDirectory3API.swift
+++ b/Sources/Paths/GetContentDirectory3API.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets Dlna content directory xml.
     static func getContentDirectory3(serverID: String) -> Request<String> {
-        Request(method: "GET", url: "/Dlna/\(serverID)/ContentDirectory/ContentDirectory.xml", id: "GetContentDirectory_3")
+        Request(path: "/Dlna/\(serverID)/ContentDirectory/ContentDirectory.xml", method: "GET", id: "GetContentDirectory_3")
     }
 }

--- a/Sources/Paths/GetContentDirectoryAPI.swift
+++ b/Sources/Paths/GetContentDirectoryAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets Dlna content directory xml.
     static func getContentDirectory(serverID: String) -> Request<String> {
-        Request(method: "GET", url: "/Dlna/\(serverID)/ContentDirectory", id: "GetContentDirectory")
+        Request(path: "/Dlna/\(serverID)/ContentDirectory", method: "GET", id: "GetContentDirectory")
     }
 }

--- a/Sources/Paths/GetCountriesAPI.swift
+++ b/Sources/Paths/GetCountriesAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets known countries.
     static var getCountries: Request<[JellyfinAPI.CountryInfo]> {
-        Request(method: "GET", url: "/Localization/Countries", id: "GetCountries")
+        Request(path: "/Localization/Countries", method: "GET", id: "GetCountries")
     }
 }

--- a/Sources/Paths/GetCriticReviewsAPI.swift
+++ b/Sources/Paths/GetCriticReviewsAPI.swift
@@ -14,6 +14,6 @@ public extension Paths {
     /// Gets critic review for an item.
     @available(*, deprecated, message: "Deprecated")
     static func getCriticReviews(itemID: String) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/Items/\(itemID)/CriticReviews", id: "GetCriticReviews")
+        Request(path: "/Items/\(itemID)/CriticReviews", method: "GET", id: "GetCriticReviews")
     }
 }

--- a/Sources/Paths/GetCulturesAPI.swift
+++ b/Sources/Paths/GetCulturesAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets known cultures.
     static var getCultures: Request<[JellyfinAPI.CultureDto]> {
-        Request(method: "GET", url: "/Localization/Cultures", id: "GetCultures")
+        Request(path: "/Localization/Cultures", method: "GET", id: "GetCultures")
     }
 }

--- a/Sources/Paths/GetCurrentUserAPI.swift
+++ b/Sources/Paths/GetCurrentUserAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets the user based on auth token.
     static var getCurrentUser: Request<JellyfinAPI.UserDto> {
-        Request(method: "GET", url: "/Users/Me", id: "GetCurrentUser")
+        Request(path: "/Users/Me", method: "GET", id: "GetCurrentUser")
     }
 }

--- a/Sources/Paths/GetDashboardConfigurationPageAPI.swift
+++ b/Sources/Paths/GetDashboardConfigurationPageAPI.swift
@@ -14,8 +14,8 @@ extension Paths {
     /// Gets a dashboard configuration page.
     public static func getDashboardConfigurationPage(name: String? = nil) -> Request<String> {
         Request(
+            path: "/web/ConfigurationPage",
             method: "GET",
-            url: "/web/ConfigurationPage",
             query: makeGetDashboardConfigurationPageQuery(name),
             id: "GetDashboardConfigurationPage"
         )

--- a/Sources/Paths/GetDefaultDirectoryBrowserAPI.swift
+++ b/Sources/Paths/GetDefaultDirectoryBrowserAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Get Default directory browser.
     static var getDefaultDirectoryBrowser: Request<JellyfinAPI.DefaultDirectoryBrowserInfoDto> {
-        Request(method: "GET", url: "/Environment/DefaultDirectoryBrowser", id: "GetDefaultDirectoryBrowser")
+        Request(path: "/Environment/DefaultDirectoryBrowser", method: "GET", id: "GetDefaultDirectoryBrowser")
     }
 }

--- a/Sources/Paths/GetDefaultListingProviderAPI.swift
+++ b/Sources/Paths/GetDefaultListingProviderAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets default listings provider info.
     static var getDefaultListingProvider: Request<JellyfinAPI.ListingsProviderInfo> {
-        Request(method: "GET", url: "/LiveTv/ListingProviders/Default", id: "GetDefaultListingProvider")
+        Request(path: "/LiveTv/ListingProviders/Default", method: "GET", id: "GetDefaultListingProvider")
     }
 }

--- a/Sources/Paths/GetDefaultMetadataOptionsAPI.swift
+++ b/Sources/Paths/GetDefaultMetadataOptionsAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets a default MetadataOptions object.
     static var getDefaultMetadataOptions: Request<JellyfinAPI.MetadataOptions> {
-        Request(method: "GET", url: "/System/Configuration/MetadataOptions/Default", id: "GetDefaultMetadataOptions")
+        Request(path: "/System/Configuration/MetadataOptions/Default", method: "GET", id: "GetDefaultMetadataOptions")
     }
 }

--- a/Sources/Paths/GetDefaultProfileAPI.swift
+++ b/Sources/Paths/GetDefaultProfileAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets the default profile.
     static var getDefaultProfile: Request<JellyfinAPI.DeviceProfile> {
-        Request(method: "GET", url: "/Dlna/Profiles/Default", id: "GetDefaultProfile")
+        Request(path: "/Dlna/Profiles/Default", method: "GET", id: "GetDefaultProfile")
     }
 }

--- a/Sources/Paths/GetDefaultTimerAPI.swift
+++ b/Sources/Paths/GetDefaultTimerAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 extension Paths {
     /// Gets the default values for a new timer.
     public static func getDefaultTimer(programID: String? = nil) -> Request<JellyfinAPI.SeriesTimerInfoDto> {
-        Request(method: "GET", url: "/LiveTv/Timers/Defaults", query: makeGetDefaultTimerQuery(programID), id: "GetDefaultTimer")
+        Request(path: "/LiveTv/Timers/Defaults", method: "GET", query: makeGetDefaultTimerQuery(programID), id: "GetDefaultTimer")
     }
 
     private static func makeGetDefaultTimerQuery(_ programID: String?) -> [(String, String?)] {

--- a/Sources/Paths/GetDescriptionXml2API.swift
+++ b/Sources/Paths/GetDescriptionXml2API.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Get Description Xml.
     static func getDescriptionXml2(serverID: String) -> Request<String> {
-        Request(method: "GET", url: "/Dlna/\(serverID)/description.xml", id: "GetDescriptionXml_2")
+        Request(path: "/Dlna/\(serverID)/description.xml", method: "GET", id: "GetDescriptionXml_2")
     }
 }

--- a/Sources/Paths/GetDescriptionXmlAPI.swift
+++ b/Sources/Paths/GetDescriptionXmlAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Get Description Xml.
     static func getDescriptionXml(serverID: String) -> Request<String> {
-        Request(method: "GET", url: "/Dlna/\(serverID)/description", id: "GetDescriptionXml")
+        Request(path: "/Dlna/\(serverID)/description", method: "GET", id: "GetDescriptionXml")
     }
 }

--- a/Sources/Paths/GetDeviceInfoAPI.swift
+++ b/Sources/Paths/GetDeviceInfoAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Get info for a device.
     static func getDeviceInfo(id: String) -> Request<JellyfinAPI.DeviceInfo> {
-        Request(method: "GET", url: "/Devices/Info", query: [("id", id)], id: "GetDeviceInfo")
+        Request(path: "/Devices/Info", method: "GET", query: [("id", id)], id: "GetDeviceInfo")
     }
 }

--- a/Sources/Paths/GetDeviceOptionsAPI.swift
+++ b/Sources/Paths/GetDeviceOptionsAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Get options for a device.
     static func getDeviceOptions(id: String) -> Request<JellyfinAPI.DeviceOptions> {
-        Request(method: "GET", url: "/Devices/Options", query: [("id", id)], id: "GetDeviceOptions")
+        Request(path: "/Devices/Options", method: "GET", query: [("id", id)], id: "GetDeviceOptions")
     }
 }

--- a/Sources/Paths/GetDevicesAPI.swift
+++ b/Sources/Paths/GetDevicesAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 extension Paths {
     /// Get Devices.
     public static func getDevices(isSupportsSync: Bool? = nil, userID: String? = nil) -> Request<JellyfinAPI.DeviceInfoQueryResult> {
-        Request(method: "GET", url: "/Devices", query: makeGetDevicesQuery(isSupportsSync, userID), id: "GetDevices")
+        Request(path: "/Devices", method: "GET", query: makeGetDevicesQuery(isSupportsSync, userID), id: "GetDevices")
     }
 
     private static func makeGetDevicesQuery(_ isSupportsSync: Bool?, _ userID: String?) -> [(String, String?)] {

--- a/Sources/Paths/GetDirectoryContentsAPI.swift
+++ b/Sources/Paths/GetDirectoryContentsAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets the contents of a given directory in the file system.
     static func getDirectoryContents(parameters: GetDirectoryContentsParameters) -> Request<[JellyfinAPI.FileSystemEntryInfo]> {
-        Request(method: "GET", url: "/Environment/DirectoryContents", query: parameters.asQuery, id: "GetDirectoryContents")
+        Request(path: "/Environment/DirectoryContents", method: "GET", query: parameters.asQuery, id: "GetDirectoryContents")
     }
 
     struct GetDirectoryContentsParameters {

--- a/Sources/Paths/GetDisplayPreferencesAPI.swift
+++ b/Sources/Paths/GetDisplayPreferencesAPI.swift
@@ -18,8 +18,8 @@ public extension Paths {
         client: String
     ) -> Request<JellyfinAPI.DisplayPreferencesDto> {
         Request(
+            path: "/DisplayPreferences/\(displayPreferencesID)",
             method: "GET",
-            url: "/DisplayPreferences/\(displayPreferencesID)",
             query: [("userId", userID), ("client", client)],
             id: "GetDisplayPreferences"
         )

--- a/Sources/Paths/GetDownloadAPI.swift
+++ b/Sources/Paths/GetDownloadAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Downloads item media.
     static func getDownload(itemID: String) -> Request<Data> {
-        Request(method: "GET", url: "/Items/\(itemID)/Download", id: "GetDownload")
+        Request(path: "/Items/\(itemID)/Download", method: "GET", id: "GetDownload")
     }
 }

--- a/Sources/Paths/GetDrivesAPI.swift
+++ b/Sources/Paths/GetDrivesAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets available drives from the server's file system.
     static var getDrives: Request<[JellyfinAPI.FileSystemEntryInfo]> {
-        Request(method: "GET", url: "/Environment/Drives", id: "GetDrives")
+        Request(path: "/Environment/Drives", method: "GET", id: "GetDrives")
     }
 }

--- a/Sources/Paths/GetEnabledAPI.swift
+++ b/Sources/Paths/GetEnabledAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets the current quick connect state.
     static var getEnabled: Request<Data> {
-        Request(method: "GET", url: "/QuickConnect/Enabled", id: "GetEnabled")
+        Request(path: "/QuickConnect/Enabled", method: "GET", id: "GetEnabled")
     }
 }

--- a/Sources/Paths/GetEndpointInfoAPI.swift
+++ b/Sources/Paths/GetEndpointInfoAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets information about the request endpoint.
     static var getEndpointInfo: Request<JellyfinAPI.EndPointInfo> {
-        Request(method: "GET", url: "/System/Endpoint", id: "GetEndpointInfo")
+        Request(path: "/System/Endpoint", method: "GET", id: "GetEndpointInfo")
     }
 }

--- a/Sources/Paths/GetEpisodesAPI.swift
+++ b/Sources/Paths/GetEpisodesAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets episodes for a tv season.
     static func getEpisodes(seriesID: String, parameters: GetEpisodesParameters? = nil) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/Shows/\(seriesID)/Episodes", query: parameters?.asQuery, id: "GetEpisodes")
+        Request(path: "/Shows/\(seriesID)/Episodes", method: "GET", query: parameters?.asQuery, id: "GetEpisodes")
     }
 
     struct GetEpisodesParameters {

--- a/Sources/Paths/GetExternalIDInfosAPI.swift
+++ b/Sources/Paths/GetExternalIDInfosAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Get the item's external id info.
     static func getExternalIDInfos(itemID: String) -> Request<[JellyfinAPI.ExternalIDInfo]> {
-        Request(method: "GET", url: "/Items/\(itemID)/ExternalIdInfos", id: "GetExternalIdInfos")
+        Request(path: "/Items/\(itemID)/ExternalIdInfos", method: "GET", id: "GetExternalIdInfos")
     }
 }

--- a/Sources/Paths/GetFallbackFontAPI.swift
+++ b/Sources/Paths/GetFallbackFontAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets a fallback font file.
     static func getFallbackFont(name: String) -> Request<Data> {
-        Request(method: "GET", url: "/FallbackFont/Fonts/\(name)", id: "GetFallbackFont")
+        Request(path: "/FallbackFont/Fonts/\(name)", method: "GET", id: "GetFallbackFont")
     }
 }

--- a/Sources/Paths/GetFallbackFontListAPI.swift
+++ b/Sources/Paths/GetFallbackFontListAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets a list of available fallback font files.
     static var getFallbackFontList: Request<[JellyfinAPI.FontFile]> {
-        Request(method: "GET", url: "/FallbackFont/Fonts", id: "GetFallbackFontList")
+        Request(path: "/FallbackFont/Fonts", method: "GET", id: "GetFallbackFontList")
     }
 }

--- a/Sources/Paths/GetFileAPI.swift
+++ b/Sources/Paths/GetFileAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Get the original file of an item.
     static func getFile(itemID: String) -> Request<Data> {
-        Request(method: "GET", url: "/Items/\(itemID)/File", id: "GetFile")
+        Request(path: "/Items/\(itemID)/File", method: "GET", id: "GetFile")
     }
 }

--- a/Sources/Paths/GetFirstUser2API.swift
+++ b/Sources/Paths/GetFirstUser2API.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets the first user.
     static var getFirstUser2: Request<JellyfinAPI.StartupUserDto> {
-        Request(method: "GET", url: "/Startup/FirstUser", id: "GetFirstUser_2")
+        Request(path: "/Startup/FirstUser", method: "GET", id: "GetFirstUser_2")
     }
 }

--- a/Sources/Paths/GetFirstUserAPI.swift
+++ b/Sources/Paths/GetFirstUserAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets the first user.
     static var getFirstUser: Request<JellyfinAPI.StartupUserDto> {
-        Request(method: "GET", url: "/Startup/User", id: "GetFirstUser")
+        Request(path: "/Startup/User", method: "GET", id: "GetFirstUser")
     }
 }

--- a/Sources/Paths/GetGeneralImageAPI.swift
+++ b/Sources/Paths/GetGeneralImageAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Get General Image.
     static func getGeneralImage(name: String, type: String) -> Request<Data> {
-        Request(method: "GET", url: "/Images/General/\(name)/\(type)", id: "GetGeneralImage")
+        Request(path: "/Images/General/\(name)/\(type)", method: "GET", id: "GetGeneralImage")
     }
 }

--- a/Sources/Paths/GetGeneralImagesAPI.swift
+++ b/Sources/Paths/GetGeneralImagesAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Get all general images.
     static var getGeneralImages: Request<[JellyfinAPI.ImageByNameInfo]> {
-        Request(method: "GET", url: "/Images/General", id: "GetGeneralImages")
+        Request(path: "/Images/General", method: "GET", id: "GetGeneralImages")
     }
 }

--- a/Sources/Paths/GetGenreAPI.swift
+++ b/Sources/Paths/GetGenreAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 extension Paths {
     /// Gets a genre, by name.
     public static func getGenre(genreName: String, userID: String? = nil) -> Request<JellyfinAPI.BaseItemDto> {
-        Request(method: "GET", url: "/Genres/\(genreName)", query: makeGetGenreQuery(userID), id: "GetGenre")
+        Request(path: "/Genres/\(genreName)", method: "GET", query: makeGetGenreQuery(userID), id: "GetGenre")
     }
 
     private static func makeGetGenreQuery(_ userID: String?) -> [(String, String?)] {

--- a/Sources/Paths/GetGenreImageAPI.swift
+++ b/Sources/Paths/GetGenreImageAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Get genre image by name.
     static func getGenreImage(name: String, imageType: String, parameters: GetGenreImageParameters? = nil) -> Request<Data> {
-        Request(method: "GET", url: "/Genres/\(name)/Images/\(imageType)", query: parameters?.asQuery, id: "GetGenreImage")
+        Request(path: "/Genres/\(name)/Images/\(imageType)", method: "GET", query: parameters?.asQuery, id: "GetGenreImage")
     }
 
     struct GetGenreImageParameters {

--- a/Sources/Paths/GetGenreImageByIndexAPI.swift
+++ b/Sources/Paths/GetGenreImageByIndexAPI.swift
@@ -19,8 +19,8 @@ public extension Paths {
         parameters: GetGenreImageByIndexParameters? = nil
     ) -> Request<Data> {
         Request(
+            path: "/Genres/\(name)/Images/\(imageType)/\(imageIndex)",
             method: "GET",
-            url: "/Genres/\(name)/Images/\(imageType)/\(imageIndex)",
             query: parameters?.asQuery,
             id: "GetGenreImageByIndex"
         )

--- a/Sources/Paths/GetGenresAPI.swift
+++ b/Sources/Paths/GetGenresAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets all genres from a given item, folder, or the entire library.
     static func getGenres(parameters: GetGenresParameters? = nil) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/Genres", query: parameters?.asQuery, id: "GetGenres")
+        Request(path: "/Genres", method: "GET", query: parameters?.asQuery, id: "GetGenres")
     }
 
     struct GetGenresParameters {

--- a/Sources/Paths/GetGroupingOptionsAPI.swift
+++ b/Sources/Paths/GetGroupingOptionsAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Get user view grouping options.
     static func getGroupingOptions(userID: String) -> Request<[JellyfinAPI.SpecialViewOptionDto]> {
-        Request(method: "GET", url: "/Users/\(userID)/GroupingOptions", id: "GetGroupingOptions")
+        Request(path: "/Users/\(userID)/GroupingOptions", method: "GET", id: "GetGroupingOptions")
     }
 }

--- a/Sources/Paths/GetGuideInfoAPI.swift
+++ b/Sources/Paths/GetGuideInfoAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Get guid info.
     static var getGuideInfo: Request<JellyfinAPI.GuideInfo> {
-        Request(method: "GET", url: "/LiveTv/GuideInfo", id: "GetGuideInfo")
+        Request(path: "/LiveTv/GuideInfo", method: "GET", id: "GetGuideInfo")
     }
 }

--- a/Sources/Paths/GetHlsAudioSegmentAPI.swift
+++ b/Sources/Paths/GetHlsAudioSegmentAPI.swift
@@ -20,8 +20,8 @@ public extension Paths {
         parameters: GetHlsAudioSegmentParameters
     ) -> Request<Data> {
         Request(
+            path: "/Audio/\(itemID)/hls1/\(playlistID)/\(segmentID).\(container)",
             method: "GET",
-            url: "/Audio/\(itemID)/hls1/\(playlistID)/\(segmentID).\(container)",
             query: parameters.asQuery,
             id: "GetHlsAudioSegment"
         )

--- a/Sources/Paths/GetHlsAudioSegmentLegacyAacAPI.swift
+++ b/Sources/Paths/GetHlsAudioSegmentLegacyAacAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets the specified audio segment for an audio item.
     static func getHlsAudioSegmentLegacyAac(itemID: String, segmentID: String) -> Request<Data> {
-        Request(method: "GET", url: "/Audio/\(itemID)/hls/\(segmentID)/stream.aac", id: "GetHlsAudioSegmentLegacyAac")
+        Request(path: "/Audio/\(itemID)/hls/\(segmentID)/stream.aac", method: "GET", id: "GetHlsAudioSegmentLegacyAac")
     }
 }

--- a/Sources/Paths/GetHlsAudioSegmentLegacyMp3API.swift
+++ b/Sources/Paths/GetHlsAudioSegmentLegacyMp3API.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets the specified audio segment for an audio item.
     static func getHlsAudioSegmentLegacyMp3(itemID: String, segmentID: String) -> Request<Data> {
-        Request(method: "GET", url: "/Audio/\(itemID)/hls/\(segmentID)/stream.mp3", id: "GetHlsAudioSegmentLegacyMp3")
+        Request(path: "/Audio/\(itemID)/hls/\(segmentID)/stream.mp3", method: "GET", id: "GetHlsAudioSegmentLegacyMp3")
     }
 }

--- a/Sources/Paths/GetHlsPlaylistLegacyAPI.swift
+++ b/Sources/Paths/GetHlsPlaylistLegacyAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets a hls video playlist.
     static func getHlsPlaylistLegacy(itemID: String, playlistID: String) -> Request<Data> {
-        Request(method: "GET", url: "/Videos/\(itemID)/hls/\(playlistID)/stream.m3u8", id: "GetHlsPlaylistLegacy")
+        Request(path: "/Videos/\(itemID)/hls/\(playlistID)/stream.m3u8", method: "GET", id: "GetHlsPlaylistLegacy")
     }
 }

--- a/Sources/Paths/GetHlsVideoSegmentAPI.swift
+++ b/Sources/Paths/GetHlsVideoSegmentAPI.swift
@@ -20,8 +20,8 @@ public extension Paths {
         parameters: GetHlsVideoSegmentParameters
     ) -> Request<Data> {
         Request(
+            path: "/Videos/\(itemID)/hls1/\(playlistID)/\(segmentID).\(container)",
             method: "GET",
-            url: "/Videos/\(itemID)/hls1/\(playlistID)/\(segmentID).\(container)",
             query: parameters.asQuery,
             id: "GetHlsVideoSegment"
         )

--- a/Sources/Paths/GetHlsVideoSegmentLegacyAPI.swift
+++ b/Sources/Paths/GetHlsVideoSegmentLegacyAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets a hls video segment.
     static func getHlsVideoSegmentLegacy(itemID: String, playlistID: String, segmentID: String, segmentContainer: String) -> Request<Data> {
-        Request(method: "GET", url: "/Videos/\(itemID)/hls/\(playlistID)/\(segmentID).\(segmentContainer)", id: "GetHlsVideoSegmentLegacy")
+        Request(path: "/Videos/\(itemID)/hls/\(playlistID)/\(segmentID).\(segmentContainer)", method: "GET", id: "GetHlsVideoSegmentLegacy")
     }
 }

--- a/Sources/Paths/GetIconAPI.swift
+++ b/Sources/Paths/GetIconAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets a server icon.
     static func getIcon(fileName: String) -> Request<Data> {
-        Request(method: "GET", url: "/Dlna/icons/\(fileName)", id: "GetIcon")
+        Request(path: "/Dlna/icons/\(fileName)", method: "GET", id: "GetIcon")
     }
 }

--- a/Sources/Paths/GetIconIDAPI.swift
+++ b/Sources/Paths/GetIconIDAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets a server icon.
     static func getIconID(serverID: String, fileName: String) -> Request<Data> {
-        Request(method: "GET", url: "/Dlna/\(serverID)/icons/\(fileName)", id: "GetIconId")
+        Request(path: "/Dlna/\(serverID)/icons/\(fileName)", method: "GET", id: "GetIconId")
     }
 }

--- a/Sources/Paths/GetInstantMixFromAlbumAPI.swift
+++ b/Sources/Paths/GetInstantMixFromAlbumAPI.swift
@@ -16,7 +16,7 @@ public extension Paths {
         id: String,
         parameters: GetInstantMixFromAlbumParameters? = nil
     ) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/Albums/\(id)/InstantMix", query: parameters?.asQuery, id: "GetInstantMixFromAlbum")
+        Request(path: "/Albums/\(id)/InstantMix", method: "GET", query: parameters?.asQuery, id: "GetInstantMixFromAlbum")
     }
 
     struct GetInstantMixFromAlbumParameters {

--- a/Sources/Paths/GetInstantMixFromArtists2API.swift
+++ b/Sources/Paths/GetInstantMixFromArtists2API.swift
@@ -14,7 +14,7 @@ public extension Paths {
     /// Creates an instant playlist based on a given artist.
     @available(*, deprecated, message: "Deprecated")
     static func getInstantMixFromArtists2(parameters: GetInstantMixFromArtists2Parameters) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/Artists/InstantMix", query: parameters.asQuery, id: "GetInstantMixFromArtists2")
+        Request(path: "/Artists/InstantMix", method: "GET", query: parameters.asQuery, id: "GetInstantMixFromArtists2")
     }
 
     struct GetInstantMixFromArtists2Parameters {

--- a/Sources/Paths/GetInstantMixFromArtistsAPI.swift
+++ b/Sources/Paths/GetInstantMixFromArtistsAPI.swift
@@ -16,7 +16,7 @@ public extension Paths {
         id: String,
         parameters: GetInstantMixFromArtistsParameters? = nil
     ) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/Artists/\(id)/InstantMix", query: parameters?.asQuery, id: "GetInstantMixFromArtists")
+        Request(path: "/Artists/\(id)/InstantMix", method: "GET", query: parameters?.asQuery, id: "GetInstantMixFromArtists")
     }
 
     struct GetInstantMixFromArtistsParameters {

--- a/Sources/Paths/GetInstantMixFromItemAPI.swift
+++ b/Sources/Paths/GetInstantMixFromItemAPI.swift
@@ -16,7 +16,7 @@ public extension Paths {
         id: String,
         parameters: GetInstantMixFromItemParameters? = nil
     ) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/Items/\(id)/InstantMix", query: parameters?.asQuery, id: "GetInstantMixFromItem")
+        Request(path: "/Items/\(id)/InstantMix", method: "GET", query: parameters?.asQuery, id: "GetInstantMixFromItem")
     }
 
     struct GetInstantMixFromItemParameters {

--- a/Sources/Paths/GetInstantMixFromMusicGenreByIDAPI.swift
+++ b/Sources/Paths/GetInstantMixFromMusicGenreByIDAPI.swift
@@ -14,7 +14,7 @@ public extension Paths {
     /// Creates an instant playlist based on a given genre.
     static func getInstantMixFromMusicGenreByID(parameters: GetInstantMixFromMusicGenreByIDParameters)
     -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/MusicGenres/InstantMix", query: parameters.asQuery, id: "GetInstantMixFromMusicGenreById")
+        Request(path: "/MusicGenres/InstantMix", method: "GET", query: parameters.asQuery, id: "GetInstantMixFromMusicGenreById")
     }
 
     struct GetInstantMixFromMusicGenreByIDParameters {

--- a/Sources/Paths/GetInstantMixFromMusicGenreByNameAPI.swift
+++ b/Sources/Paths/GetInstantMixFromMusicGenreByNameAPI.swift
@@ -16,7 +16,7 @@ public extension Paths {
         name: String,
         parameters: GetInstantMixFromMusicGenreByNameParameters? = nil
     ) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/MusicGenres/\(name)/InstantMix", query: parameters?.asQuery, id: "GetInstantMixFromMusicGenreByName")
+        Request(path: "/MusicGenres/\(name)/InstantMix", method: "GET", query: parameters?.asQuery, id: "GetInstantMixFromMusicGenreByName")
     }
 
     struct GetInstantMixFromMusicGenreByNameParameters {

--- a/Sources/Paths/GetInstantMixFromPlaylistAPI.swift
+++ b/Sources/Paths/GetInstantMixFromPlaylistAPI.swift
@@ -16,7 +16,7 @@ public extension Paths {
         id: String,
         parameters: GetInstantMixFromPlaylistParameters? = nil
     ) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/Playlists/\(id)/InstantMix", query: parameters?.asQuery, id: "GetInstantMixFromPlaylist")
+        Request(path: "/Playlists/\(id)/InstantMix", method: "GET", query: parameters?.asQuery, id: "GetInstantMixFromPlaylist")
     }
 
     struct GetInstantMixFromPlaylistParameters {

--- a/Sources/Paths/GetInstantMixFromSongAPI.swift
+++ b/Sources/Paths/GetInstantMixFromSongAPI.swift
@@ -16,7 +16,7 @@ public extension Paths {
         id: String,
         parameters: GetInstantMixFromSongParameters? = nil
     ) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/Songs/\(id)/InstantMix", query: parameters?.asQuery, id: "GetInstantMixFromSong")
+        Request(path: "/Songs/\(id)/InstantMix", method: "GET", query: parameters?.asQuery, id: "GetInstantMixFromSong")
     }
 
     struct GetInstantMixFromSongParameters {

--- a/Sources/Paths/GetIntrosAPI.swift
+++ b/Sources/Paths/GetIntrosAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets intros to play before the main media item plays.
     static func getIntros(userID: String, itemID: String) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/Users/\(userID)/Items/\(itemID)/Intros", id: "GetIntros")
+        Request(path: "/Users/\(userID)/Items/\(itemID)/Intros", method: "GET", id: "GetIntros")
     }
 }

--- a/Sources/Paths/GetItemAPI.swift
+++ b/Sources/Paths/GetItemAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets an item from a user's library.
     static func getItem(userID: String, itemID: String) -> Request<JellyfinAPI.BaseItemDto> {
-        Request(method: "GET", url: "/Users/\(userID)/Items/\(itemID)", id: "GetItem")
+        Request(path: "/Users/\(userID)/Items/\(itemID)", method: "GET", id: "GetItem")
     }
 }

--- a/Sources/Paths/GetItemCountsAPI.swift
+++ b/Sources/Paths/GetItemCountsAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 extension Paths {
     /// Get item counts.
     public static func getItemCounts(userID: String? = nil, isFavorite: Bool? = nil) -> Request<JellyfinAPI.ItemCounts> {
-        Request(method: "GET", url: "/Items/Counts", query: makeGetItemCountsQuery(userID, isFavorite), id: "GetItemCounts")
+        Request(path: "/Items/Counts", method: "GET", query: makeGetItemCountsQuery(userID, isFavorite), id: "GetItemCounts")
     }
 
     private static func makeGetItemCountsQuery(_ userID: String?, _ isFavorite: Bool?) -> [(String, String?)] {

--- a/Sources/Paths/GetItemImage2API.swift
+++ b/Sources/Paths/GetItemImage2API.swift
@@ -25,8 +25,8 @@ public extension Paths {
         parameters: GetItemImage2Parameters? = nil
     ) -> Request<Data> {
         Request(
+            path: "/Items/\(itemID)/Images/\(imageType)/\(imageIndex)/\(tag)/\(format)/\(maxWidth)/\(maxHeight)/\(percentPlayed)/\(unplayedCount)",
             method: "GET",
-            url: "/Items/\(itemID)/Images/\(imageType)/\(imageIndex)/\(tag)/\(format)/\(maxWidth)/\(maxHeight)/\(percentPlayed)/\(unplayedCount)",
             query: parameters?.asQuery,
             id: "GetItemImage2"
         )

--- a/Sources/Paths/GetItemImageAPI.swift
+++ b/Sources/Paths/GetItemImageAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets the item's image.
     static func getItemImage(itemID: String, imageType: String, parameters: GetItemImageParameters? = nil) -> Request<Data> {
-        Request(method: "GET", url: "/Items/\(itemID)/Images/\(imageType)", query: parameters?.asQuery, id: "GetItemImage")
+        Request(path: "/Items/\(itemID)/Images/\(imageType)", method: "GET", query: parameters?.asQuery, id: "GetItemImage")
     }
 
     struct GetItemImageParameters {

--- a/Sources/Paths/GetItemImageByIndexAPI.swift
+++ b/Sources/Paths/GetItemImageByIndexAPI.swift
@@ -19,8 +19,8 @@ public extension Paths {
         parameters: GetItemImageByIndexParameters? = nil
     ) -> Request<Data> {
         Request(
+            path: "/Items/\(itemID)/Images/\(imageType)/\(imageIndex)",
             method: "GET",
-            url: "/Items/\(itemID)/Images/\(imageType)/\(imageIndex)",
             query: parameters?.asQuery,
             id: "GetItemImageByIndex"
         )

--- a/Sources/Paths/GetItemImageInfosAPI.swift
+++ b/Sources/Paths/GetItemImageInfosAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Get item image infos.
     static func getItemImageInfos(itemID: String) -> Request<[JellyfinAPI.ImageInfo]> {
-        Request(method: "GET", url: "/Items/\(itemID)/Images", id: "GetItemImageInfos")
+        Request(path: "/Items/\(itemID)/Images", method: "GET", id: "GetItemImageInfos")
     }
 }

--- a/Sources/Paths/GetItemsAPI.swift
+++ b/Sources/Paths/GetItemsAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets items based on a query.
     static func getItems(parameters: GetItemsParameters? = nil) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/Items", query: parameters?.asQuery, id: "GetItems")
+        Request(path: "/Items", method: "GET", query: parameters?.asQuery, id: "GetItems")
     }
 
     struct GetItemsParameters {

--- a/Sources/Paths/GetItemsByUserIDAPI.swift
+++ b/Sources/Paths/GetItemsByUserIDAPI.swift
@@ -16,7 +16,7 @@ public extension Paths {
         userID: String,
         parameters: GetItemsByUserIDParameters? = nil
     ) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/Users/\(userID)/Items", query: parameters?.asQuery, id: "GetItemsByUserId")
+        Request(path: "/Users/\(userID)/Items", method: "GET", query: parameters?.asQuery, id: "GetItemsByUserId")
     }
 
     struct GetItemsByUserIDParameters {

--- a/Sources/Paths/GetKeysAPI.swift
+++ b/Sources/Paths/GetKeysAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Get all keys.
     static var getKeys: Request<JellyfinAPI.AuthenticationInfoQueryResult> {
-        Request(method: "GET", url: "/Auth/Keys", id: "GetKeys")
+        Request(path: "/Auth/Keys", method: "GET", id: "GetKeys")
     }
 }

--- a/Sources/Paths/GetLatestChannelItemsAPI.swift
+++ b/Sources/Paths/GetLatestChannelItemsAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets latest channel items.
     static func getLatestChannelItems(parameters: GetLatestChannelItemsParameters? = nil) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/Channels/Items/Latest", query: parameters?.asQuery, id: "GetLatestChannelItems")
+        Request(path: "/Channels/Items/Latest", method: "GET", query: parameters?.asQuery, id: "GetLatestChannelItems")
     }
 
     struct GetLatestChannelItemsParameters {

--- a/Sources/Paths/GetLatestMediaAPI.swift
+++ b/Sources/Paths/GetLatestMediaAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets latest media.
     static func getLatestMedia(userID: String, parameters: GetLatestMediaParameters? = nil) -> Request<[JellyfinAPI.BaseItemDto]> {
-        Request(method: "GET", url: "/Users/\(userID)/Items/Latest", query: parameters?.asQuery, id: "GetLatestMedia")
+        Request(path: "/Users/\(userID)/Items/Latest", method: "GET", query: parameters?.asQuery, id: "GetLatestMedia")
     }
 
     struct GetLatestMediaParameters {

--- a/Sources/Paths/GetLibraryOptionsInfoAPI.swift
+++ b/Sources/Paths/GetLibraryOptionsInfoAPI.swift
@@ -17,8 +17,8 @@ extension Paths {
         isNewLibrary: Bool? = nil
     ) -> Request<JellyfinAPI.LibraryOptionsResultDto> {
         Request(
+            path: "/Libraries/AvailableOptions",
             method: "GET",
-            url: "/Libraries/AvailableOptions",
             query: makeGetLibraryOptionsInfoQuery(libraryContentType, isNewLibrary),
             id: "GetLibraryOptionsInfo"
         )

--- a/Sources/Paths/GetLineupsAPI.swift
+++ b/Sources/Paths/GetLineupsAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets available lineups.
     static func getLineups(parameters: GetLineupsParameters? = nil) -> Request<[JellyfinAPI.NameIDPair]> {
-        Request(method: "GET", url: "/LiveTv/ListingProviders/Lineups", query: parameters?.asQuery, id: "GetLineups")
+        Request(path: "/LiveTv/ListingProviders/Lineups", method: "GET", query: parameters?.asQuery, id: "GetLineups")
     }
 
     struct GetLineupsParameters {

--- a/Sources/Paths/GetLiveHlsStreamAPI.swift
+++ b/Sources/Paths/GetLiveHlsStreamAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets a hls live stream.
     static func getLiveHlsStream(itemID: String, parameters: GetLiveHlsStreamParameters? = nil) -> Request<Data> {
-        Request(method: "GET", url: "/Videos/\(itemID)/live.m3u8", query: parameters?.asQuery, id: "GetLiveHlsStream")
+        Request(path: "/Videos/\(itemID)/live.m3u8", method: "GET", query: parameters?.asQuery, id: "GetLiveHlsStream")
     }
 
     struct GetLiveHlsStreamParameters {

--- a/Sources/Paths/GetLiveRecordingFileAPI.swift
+++ b/Sources/Paths/GetLiveRecordingFileAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets a live tv recording stream.
     static func getLiveRecordingFile(recordingID: String) -> Request<Data> {
-        Request(method: "GET", url: "/LiveTv/LiveRecordings/\(recordingID)/stream", id: "GetLiveRecordingFile")
+        Request(path: "/LiveTv/LiveRecordings/\(recordingID)/stream", method: "GET", id: "GetLiveRecordingFile")
     }
 }

--- a/Sources/Paths/GetLiveStreamFileAPI.swift
+++ b/Sources/Paths/GetLiveStreamFileAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets a live tv channel stream.
     static func getLiveStreamFile(streamID: String, container: String) -> Request<Data> {
-        Request(method: "GET", url: "/LiveTv/LiveStreamFiles/\(streamID)/stream.\(container)", id: "GetLiveStreamFile")
+        Request(path: "/LiveTv/LiveStreamFiles/\(streamID)/stream.\(container)", method: "GET", id: "GetLiveStreamFile")
     }
 }

--- a/Sources/Paths/GetLiveTvChannelsAPI.swift
+++ b/Sources/Paths/GetLiveTvChannelsAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets available live tv channels.
     static func getLiveTvChannels(parameters: GetLiveTvChannelsParameters? = nil) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/LiveTv/Channels", query: parameters?.asQuery, id: "GetLiveTvChannels")
+        Request(path: "/LiveTv/Channels", method: "GET", query: parameters?.asQuery, id: "GetLiveTvChannels")
     }
 
     struct GetLiveTvChannelsParameters {

--- a/Sources/Paths/GetLiveTvInfoAPI.swift
+++ b/Sources/Paths/GetLiveTvInfoAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets available live tv services.
     static var getLiveTvInfo: Request<JellyfinAPI.LiveTvInfo> {
-        Request(method: "GET", url: "/LiveTv/Info", id: "GetLiveTvInfo")
+        Request(path: "/LiveTv/Info", method: "GET", id: "GetLiveTvInfo")
     }
 }

--- a/Sources/Paths/GetLiveTvProgramsAPI.swift
+++ b/Sources/Paths/GetLiveTvProgramsAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets available live tv epgs.
     static func getLiveTvPrograms(parameters: GetLiveTvProgramsParameters? = nil) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/LiveTv/Programs", query: parameters?.asQuery, id: "GetLiveTvPrograms")
+        Request(path: "/LiveTv/Programs", method: "GET", query: parameters?.asQuery, id: "GetLiveTvPrograms")
     }
 
     struct GetLiveTvProgramsParameters {

--- a/Sources/Paths/GetLocalTrailersAPI.swift
+++ b/Sources/Paths/GetLocalTrailersAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets local trailers for an item.
     static func getLocalTrailers(userID: String, itemID: String) -> Request<[JellyfinAPI.BaseItemDto]> {
-        Request(method: "GET", url: "/Users/\(userID)/Items/\(itemID)/LocalTrailers", id: "GetLocalTrailers")
+        Request(path: "/Users/\(userID)/Items/\(itemID)/LocalTrailers", method: "GET", id: "GetLocalTrailers")
     }
 }

--- a/Sources/Paths/GetLocalizationOptionsAPI.swift
+++ b/Sources/Paths/GetLocalizationOptionsAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets localization options.
     static var getLocalizationOptions: Request<[JellyfinAPI.LocalizationOption]> {
-        Request(method: "GET", url: "/Localization/Options", id: "GetLocalizationOptions")
+        Request(path: "/Localization/Options", method: "GET", id: "GetLocalizationOptions")
     }
 }

--- a/Sources/Paths/GetLogEntriesAPI.swift
+++ b/Sources/Paths/GetLogEntriesAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets activity log entries.
     static func getLogEntries(parameters: GetLogEntriesParameters? = nil) -> Request<JellyfinAPI.ActivityLogEntryQueryResult> {
-        Request(method: "GET", url: "/System/ActivityLog/Entries", query: parameters?.asQuery, id: "GetLogEntries")
+        Request(path: "/System/ActivityLog/Entries", method: "GET", query: parameters?.asQuery, id: "GetLogEntries")
     }
 
     struct GetLogEntriesParameters {

--- a/Sources/Paths/GetLogFileAPI.swift
+++ b/Sources/Paths/GetLogFileAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets a log file.
     static func getLogFile(name: String) -> Request<String> {
-        Request(method: "GET", url: "/System/Logs/Log", query: [("name", name)], id: "GetLogFile")
+        Request(path: "/System/Logs/Log", method: "GET", query: [("name", name)], id: "GetLogFile")
     }
 }

--- a/Sources/Paths/GetMasterHlsAudioPlaylistAPI.swift
+++ b/Sources/Paths/GetMasterHlsAudioPlaylistAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets an audio hls playlist stream.
     static func getMasterHlsAudioPlaylist(itemID: String, parameters: GetMasterHlsAudioPlaylistParameters) -> Request<Data> {
-        Request(method: "GET", url: "/Audio/\(itemID)/master.m3u8", query: parameters.asQuery, id: "GetMasterHlsAudioPlaylist")
+        Request(path: "/Audio/\(itemID)/master.m3u8", method: "GET", query: parameters.asQuery, id: "GetMasterHlsAudioPlaylist")
     }
 
     struct GetMasterHlsAudioPlaylistParameters {

--- a/Sources/Paths/GetMasterHlsVideoPlaylistAPI.swift
+++ b/Sources/Paths/GetMasterHlsVideoPlaylistAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets a video hls playlist stream.
     static func getMasterHlsVideoPlaylist(itemID: String, parameters: GetMasterHlsVideoPlaylistParameters) -> Request<Data> {
-        Request(method: "GET", url: "/Videos/\(itemID)/master.m3u8", query: parameters.asQuery, id: "GetMasterHlsVideoPlaylist")
+        Request(path: "/Videos/\(itemID)/master.m3u8", method: "GET", query: parameters.asQuery, id: "GetMasterHlsVideoPlaylist")
     }
 
     struct GetMasterHlsVideoPlaylistParameters {

--- a/Sources/Paths/GetMediaFoldersAPI.swift
+++ b/Sources/Paths/GetMediaFoldersAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 extension Paths {
     /// Gets all user media folders.
     public static func getMediaFolders(isHidden: Bool? = nil) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/Library/MediaFolders", query: makeGetMediaFoldersQuery(isHidden), id: "GetMediaFolders")
+        Request(path: "/Library/MediaFolders", method: "GET", query: makeGetMediaFoldersQuery(isHidden), id: "GetMediaFolders")
     }
 
     private static func makeGetMediaFoldersQuery(_ isHidden: Bool?) -> [(String, String?)] {

--- a/Sources/Paths/GetMediaInfoImageAPI.swift
+++ b/Sources/Paths/GetMediaInfoImageAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Get media info image.
     static func getMediaInfoImage(theme: String, name: String) -> Request<Data> {
-        Request(method: "GET", url: "/Images/MediaInfo/\(theme)/\(name)", id: "GetMediaInfoImage")
+        Request(path: "/Images/MediaInfo/\(theme)/\(name)", method: "GET", id: "GetMediaInfoImage")
     }
 }

--- a/Sources/Paths/GetMediaInfoImagesAPI.swift
+++ b/Sources/Paths/GetMediaInfoImagesAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Get all media info images.
     static var getMediaInfoImages: Request<[JellyfinAPI.ImageByNameInfo]> {
-        Request(method: "GET", url: "/Images/MediaInfo", id: "GetMediaInfoImages")
+        Request(path: "/Images/MediaInfo", method: "GET", id: "GetMediaInfoImages")
     }
 }

--- a/Sources/Paths/GetMediaReceiverRegistrar2API.swift
+++ b/Sources/Paths/GetMediaReceiverRegistrar2API.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets Dlna media receiver registrar xml.
     static func getMediaReceiverRegistrar2(serverID: String) -> Request<String> {
-        Request(method: "GET", url: "/Dlna/\(serverID)/MediaReceiverRegistrar/MediaReceiverRegistrar", id: "GetMediaReceiverRegistrar_2")
+        Request(path: "/Dlna/\(serverID)/MediaReceiverRegistrar/MediaReceiverRegistrar", method: "GET", id: "GetMediaReceiverRegistrar_2")
     }
 }

--- a/Sources/Paths/GetMediaReceiverRegistrar3API.swift
+++ b/Sources/Paths/GetMediaReceiverRegistrar3API.swift
@@ -14,8 +14,8 @@ public extension Paths {
     /// Gets Dlna media receiver registrar xml.
     static func getMediaReceiverRegistrar3(serverID: String) -> Request<String> {
         Request(
+            path: "/Dlna/\(serverID)/MediaReceiverRegistrar/MediaReceiverRegistrar.xml",
             method: "GET",
-            url: "/Dlna/\(serverID)/MediaReceiverRegistrar/MediaReceiverRegistrar.xml",
             id: "GetMediaReceiverRegistrar_3"
         )
     }

--- a/Sources/Paths/GetMediaReceiverRegistrarAPI.swift
+++ b/Sources/Paths/GetMediaReceiverRegistrarAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets Dlna media receiver registrar xml.
     static func getMediaReceiverRegistrar(serverID: String) -> Request<String> {
-        Request(method: "GET", url: "/Dlna/\(serverID)/MediaReceiverRegistrar", id: "GetMediaReceiverRegistrar")
+        Request(path: "/Dlna/\(serverID)/MediaReceiverRegistrar", method: "GET", id: "GetMediaReceiverRegistrar")
     }
 }

--- a/Sources/Paths/GetMetadataEditorInfoAPI.swift
+++ b/Sources/Paths/GetMetadataEditorInfoAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets metadata editor info for an item.
     static func getMetadataEditorInfo(itemID: String) -> Request<JellyfinAPI.MetadataEditorInfo> {
-        Request(method: "GET", url: "/Items/\(itemID)/MetadataEditor", id: "GetMetadataEditorInfo")
+        Request(path: "/Items/\(itemID)/MetadataEditor", method: "GET", id: "GetMetadataEditorInfo")
     }
 }

--- a/Sources/Paths/GetMovieRecommendationsAPI.swift
+++ b/Sources/Paths/GetMovieRecommendationsAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets movie recommendations.
     static func getMovieRecommendations(parameters: GetMovieRecommendationsParameters? = nil) -> Request<[JellyfinAPI.RecommendationDto]> {
-        Request(method: "GET", url: "/Movies/Recommendations", query: parameters?.asQuery, id: "GetMovieRecommendations")
+        Request(path: "/Movies/Recommendations", method: "GET", query: parameters?.asQuery, id: "GetMovieRecommendations")
     }
 
     struct GetMovieRecommendationsParameters {

--- a/Sources/Paths/GetMovieRemoteSearchResultsAPI.swift
+++ b/Sources/Paths/GetMovieRemoteSearchResultsAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Get movie remote search.
     static func getMovieRemoteSearchResults(_ body: JellyfinAPI.MovieInfoRemoteSearchQuery) -> Request<[JellyfinAPI.RemoteSearchResult]> {
-        Request(method: "POST", url: "/Items/RemoteSearch/Movie", body: body, id: "GetMovieRemoteSearchResults")
+        Request(path: "/Items/RemoteSearch/Movie", method: "POST", body: body, id: "GetMovieRemoteSearchResults")
     }
 }

--- a/Sources/Paths/GetMusicAlbumRemoteSearchResultsAPI.swift
+++ b/Sources/Paths/GetMusicAlbumRemoteSearchResultsAPI.swift
@@ -16,6 +16,6 @@ public extension Paths {
         _ body: JellyfinAPI
             .AlbumInfoRemoteSearchQuery
     ) -> Request<[JellyfinAPI.RemoteSearchResult]> {
-        Request(method: "POST", url: "/Items/RemoteSearch/MusicAlbum", body: body, id: "GetMusicAlbumRemoteSearchResults")
+        Request(path: "/Items/RemoteSearch/MusicAlbum", method: "POST", body: body, id: "GetMusicAlbumRemoteSearchResults")
     }
 }

--- a/Sources/Paths/GetMusicArtistRemoteSearchResultsAPI.swift
+++ b/Sources/Paths/GetMusicArtistRemoteSearchResultsAPI.swift
@@ -16,6 +16,6 @@ public extension Paths {
         _ body: JellyfinAPI
             .ArtistInfoRemoteSearchQuery
     ) -> Request<[JellyfinAPI.RemoteSearchResult]> {
-        Request(method: "POST", url: "/Items/RemoteSearch/MusicArtist", body: body, id: "GetMusicArtistRemoteSearchResults")
+        Request(path: "/Items/RemoteSearch/MusicArtist", method: "POST", body: body, id: "GetMusicArtistRemoteSearchResults")
     }
 }

--- a/Sources/Paths/GetMusicGenreAPI.swift
+++ b/Sources/Paths/GetMusicGenreAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 extension Paths {
     /// Gets a music genre, by name.
     public static func getMusicGenre(genreName: String, userID: String? = nil) -> Request<JellyfinAPI.BaseItemDto> {
-        Request(method: "GET", url: "/MusicGenres/\(genreName)", query: makeGetMusicGenreQuery(userID), id: "GetMusicGenre")
+        Request(path: "/MusicGenres/\(genreName)", method: "GET", query: makeGetMusicGenreQuery(userID), id: "GetMusicGenre")
     }
 
     private static func makeGetMusicGenreQuery(_ userID: String?) -> [(String, String?)] {

--- a/Sources/Paths/GetMusicGenreImageAPI.swift
+++ b/Sources/Paths/GetMusicGenreImageAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Get music genre image by name.
     static func getMusicGenreImage(name: String, imageType: String, parameters: GetMusicGenreImageParameters? = nil) -> Request<Data> {
-        Request(method: "GET", url: "/MusicGenres/\(name)/Images/\(imageType)", query: parameters?.asQuery, id: "GetMusicGenreImage")
+        Request(path: "/MusicGenres/\(name)/Images/\(imageType)", method: "GET", query: parameters?.asQuery, id: "GetMusicGenreImage")
     }
 
     struct GetMusicGenreImageParameters {

--- a/Sources/Paths/GetMusicGenreImageByIndexAPI.swift
+++ b/Sources/Paths/GetMusicGenreImageByIndexAPI.swift
@@ -19,8 +19,8 @@ public extension Paths {
         parameters: GetMusicGenreImageByIndexParameters? = nil
     ) -> Request<Data> {
         Request(
+            path: "/MusicGenres/\(name)/Images/\(imageType)/\(imageIndex)",
             method: "GET",
-            url: "/MusicGenres/\(name)/Images/\(imageType)/\(imageIndex)",
             query: parameters?.asQuery,
             id: "GetMusicGenreImageByIndex"
         )

--- a/Sources/Paths/GetMusicGenresAPI.swift
+++ b/Sources/Paths/GetMusicGenresAPI.swift
@@ -14,7 +14,7 @@ public extension Paths {
     /// Gets all music genres from a given item, folder, or the entire library.
     @available(*, deprecated, message: "Deprecated")
     static func getMusicGenres(parameters: GetMusicGenresParameters? = nil) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/MusicGenres", query: parameters?.asQuery, id: "GetMusicGenres")
+        Request(path: "/MusicGenres", method: "GET", query: parameters?.asQuery, id: "GetMusicGenres")
     }
 
     struct GetMusicGenresParameters {

--- a/Sources/Paths/GetMusicVideoRemoteSearchResultsAPI.swift
+++ b/Sources/Paths/GetMusicVideoRemoteSearchResultsAPI.swift
@@ -16,6 +16,6 @@ public extension Paths {
         _ body: JellyfinAPI
             .MusicVideoInfoRemoteSearchQuery
     ) -> Request<[JellyfinAPI.RemoteSearchResult]> {
-        Request(method: "POST", url: "/Items/RemoteSearch/MusicVideo", body: body, id: "GetMusicVideoRemoteSearchResults")
+        Request(path: "/Items/RemoteSearch/MusicVideo", method: "POST", body: body, id: "GetMusicVideoRemoteSearchResults")
     }
 }

--- a/Sources/Paths/GetNamedConfigurationAPI.swift
+++ b/Sources/Paths/GetNamedConfigurationAPI.swift
@@ -12,7 +12,7 @@ import URLQueryEncoder
 
 public extension Paths {
     /// Gets a named configuration.
-    static func getNamedConfiguration(key: String) -> Request<String> {
-        Request(method: "GET", url: "/System/Configuration/\(key)", id: "GetNamedConfiguration")
+    static func getNamedConfiguration(key: String) -> Request<Data> {
+        Request(path: "/System/Configuration/\(key)", method: "GET", id: "GetNamedConfiguration")
     }
 }

--- a/Sources/Paths/GetNetworkSharesAPI.swift
+++ b/Sources/Paths/GetNetworkSharesAPI.swift
@@ -14,6 +14,6 @@ public extension Paths {
     /// Gets network paths.
     @available(*, deprecated, message: "Deprecated")
     static var getNetworkShares: Request<[JellyfinAPI.FileSystemEntryInfo]> {
-        Request(method: "GET", url: "/Environment/NetworkShares", id: "GetNetworkShares")
+        Request(path: "/Environment/NetworkShares", method: "GET", id: "GetNetworkShares")
     }
 }

--- a/Sources/Paths/GetNextUpAPI.swift
+++ b/Sources/Paths/GetNextUpAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets a list of next up episodes.
     static func getNextUp(parameters: GetNextUpParameters? = nil) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/Shows/NextUp", query: parameters?.asQuery, id: "GetNextUp")
+        Request(path: "/Shows/NextUp", method: "GET", query: parameters?.asQuery, id: "GetNextUp")
     }
 
     struct GetNextUpParameters {

--- a/Sources/Paths/GetNotificationServicesAPI.swift
+++ b/Sources/Paths/GetNotificationServicesAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets notification services.
     static var getNotificationServices: Request<[JellyfinAPI.NameIDPair]> {
-        Request(method: "GET", url: "/Notifications/Services", id: "GetNotificationServices")
+        Request(path: "/Notifications/Services", method: "GET", id: "GetNotificationServices")
     }
 }

--- a/Sources/Paths/GetNotificationTypesAPI.swift
+++ b/Sources/Paths/GetNotificationTypesAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets notification types.
     static var getNotificationTypes: Request<[JellyfinAPI.NotificationTypeInfo]> {
-        Request(method: "GET", url: "/Notifications/Types", id: "GetNotificationTypes")
+        Request(path: "/Notifications/Types", method: "GET", id: "GetNotificationTypes")
     }
 }

--- a/Sources/Paths/GetNotificationsAPI.swift
+++ b/Sources/Paths/GetNotificationsAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets a user's notifications.
     static func getNotifications(userID: String) -> Request<JellyfinAPI.NotificationResultDto> {
-        Request(method: "GET", url: "/Notifications/\(userID)", id: "GetNotifications")
+        Request(path: "/Notifications/\(userID)", method: "GET", id: "GetNotifications")
     }
 }

--- a/Sources/Paths/GetNotificationsSummaryAPI.swift
+++ b/Sources/Paths/GetNotificationsSummaryAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets a user's notification summary.
     static func getNotificationsSummary(userID: String) -> Request<JellyfinAPI.NotificationsSummaryDto> {
-        Request(method: "GET", url: "/Notifications/\(userID)/Summary", id: "GetNotificationsSummary")
+        Request(path: "/Notifications/\(userID)/Summary", method: "GET", id: "GetNotificationsSummary")
     }
 }

--- a/Sources/Paths/GetPackageInfoAPI.swift
+++ b/Sources/Paths/GetPackageInfoAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 extension Paths {
     /// Gets a package by name or assembly GUID.
     public static func getPackageInfo(name: String, assemblyGuid: String? = nil) -> Request<JellyfinAPI.PackageInfo> {
-        Request(method: "GET", url: "/Packages/\(name)", query: makeGetPackageInfoQuery(assemblyGuid), id: "GetPackageInfo")
+        Request(path: "/Packages/\(name)", method: "GET", query: makeGetPackageInfoQuery(assemblyGuid), id: "GetPackageInfo")
     }
 
     private static func makeGetPackageInfoQuery(_ assemblyGuid: String?) -> [(String, String?)] {

--- a/Sources/Paths/GetPackagesAPI.swift
+++ b/Sources/Paths/GetPackagesAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets available packages.
     static var getPackages: Request<[JellyfinAPI.PackageInfo]> {
-        Request(method: "GET", url: "/Packages", id: "GetPackages")
+        Request(path: "/Packages", method: "GET", id: "GetPackages")
     }
 }

--- a/Sources/Paths/GetParentPathAPI.swift
+++ b/Sources/Paths/GetParentPathAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets the parent path of a given path.
     static func getParentPath(path: String) -> Request<String> {
-        Request(method: "GET", url: "/Environment/ParentPath", query: [("path", path)], id: "GetParentPath")
+        Request(path: "/Environment/ParentPath", method: "GET", query: [("path", path)], id: "GetParentPath")
     }
 }

--- a/Sources/Paths/GetParentalRatingsAPI.swift
+++ b/Sources/Paths/GetParentalRatingsAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets known parental ratings.
     static var getParentalRatings: Request<[JellyfinAPI.ParentalRating]> {
-        Request(method: "GET", url: "/Localization/ParentalRatings", id: "GetParentalRatings")
+        Request(path: "/Localization/ParentalRatings", method: "GET", id: "GetParentalRatings")
     }
 }

--- a/Sources/Paths/GetPasswordResetProvidersAPI.swift
+++ b/Sources/Paths/GetPasswordResetProvidersAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Get all password reset providers.
     static var getPasswordResetProviders: Request<[JellyfinAPI.NameIDPair]> {
-        Request(method: "GET", url: "/Auth/PasswordResetProviders", id: "GetPasswordResetProviders")
+        Request(path: "/Auth/PasswordResetProviders", method: "GET", id: "GetPasswordResetProviders")
     }
 }

--- a/Sources/Paths/GetPersonAPI.swift
+++ b/Sources/Paths/GetPersonAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 extension Paths {
     /// Get person by name.
     public static func getPerson(name: String, userID: String? = nil) -> Request<JellyfinAPI.BaseItemDto> {
-        Request(method: "GET", url: "/Persons/\(name)", query: makeGetPersonQuery(userID), id: "GetPerson")
+        Request(path: "/Persons/\(name)", method: "GET", query: makeGetPersonQuery(userID), id: "GetPerson")
     }
 
     private static func makeGetPersonQuery(_ userID: String?) -> [(String, String?)] {

--- a/Sources/Paths/GetPersonImageAPI.swift
+++ b/Sources/Paths/GetPersonImageAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Get person image by name.
     static func getPersonImage(name: String, imageType: String, parameters: GetPersonImageParameters? = nil) -> Request<Data> {
-        Request(method: "GET", url: "/Persons/\(name)/Images/\(imageType)", query: parameters?.asQuery, id: "GetPersonImage")
+        Request(path: "/Persons/\(name)/Images/\(imageType)", method: "GET", query: parameters?.asQuery, id: "GetPersonImage")
     }
 
     struct GetPersonImageParameters {

--- a/Sources/Paths/GetPersonImageByIndexAPI.swift
+++ b/Sources/Paths/GetPersonImageByIndexAPI.swift
@@ -19,8 +19,8 @@ public extension Paths {
         parameters: GetPersonImageByIndexParameters? = nil
     ) -> Request<Data> {
         Request(
+            path: "/Persons/\(name)/Images/\(imageType)/\(imageIndex)",
             method: "GET",
-            url: "/Persons/\(name)/Images/\(imageType)/\(imageIndex)",
             query: parameters?.asQuery,
             id: "GetPersonImageByIndex"
         )

--- a/Sources/Paths/GetPersonRemoteSearchResultsAPI.swift
+++ b/Sources/Paths/GetPersonRemoteSearchResultsAPI.swift
@@ -16,6 +16,6 @@ public extension Paths {
         _ body: JellyfinAPI
             .PersonLookupInfoRemoteSearchQuery
     ) -> Request<[JellyfinAPI.RemoteSearchResult]> {
-        Request(method: "POST", url: "/Items/RemoteSearch/Person", body: body, id: "GetPersonRemoteSearchResults")
+        Request(path: "/Items/RemoteSearch/Person", method: "POST", body: body, id: "GetPersonRemoteSearchResults")
     }
 }

--- a/Sources/Paths/GetPersonsAPI.swift
+++ b/Sources/Paths/GetPersonsAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets all persons.
     static func getPersons(parameters: GetPersonsParameters? = nil) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/Persons", query: parameters?.asQuery, id: "GetPersons")
+        Request(path: "/Persons", method: "GET", query: parameters?.asQuery, id: "GetPersons")
     }
 
     struct GetPersonsParameters {

--- a/Sources/Paths/GetPhysicalPathsAPI.swift
+++ b/Sources/Paths/GetPhysicalPathsAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets a list of physical paths from virtual folders.
     static var getPhysicalPaths: Request<[String]> {
-        Request(method: "GET", url: "/Library/PhysicalPaths", id: "GetPhysicalPaths")
+        Request(path: "/Library/PhysicalPaths", method: "GET", id: "GetPhysicalPaths")
     }
 }

--- a/Sources/Paths/GetPingSystemAPI.swift
+++ b/Sources/Paths/GetPingSystemAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Pings the system.
     static var getPingSystem: Request<String> {
-        Request(method: "GET", url: "/System/Ping", id: "GetPingSystem")
+        Request(path: "/System/Ping", method: "GET", id: "GetPingSystem")
     }
 }

--- a/Sources/Paths/GetPlaybackInfoAPI.swift
+++ b/Sources/Paths/GetPlaybackInfoAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets live playback media info for an item.
     static func getPlaybackInfo(itemID: String, userID: String) -> Request<JellyfinAPI.PlaybackInfoResponse> {
-        Request(method: "GET", url: "/Items/\(itemID)/PlaybackInfo", query: [("userId", userID)], id: "GetPlaybackInfo")
+        Request(path: "/Items/\(itemID)/PlaybackInfo", method: "GET", query: [("userId", userID)], id: "GetPlaybackInfo")
     }
 }

--- a/Sources/Paths/GetPlaylistItemsAPI.swift
+++ b/Sources/Paths/GetPlaylistItemsAPI.swift
@@ -16,7 +16,7 @@ public extension Paths {
         playlistID: String,
         parameters: GetPlaylistItemsParameters
     ) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/Playlists/\(playlistID)/Items", query: parameters.asQuery, id: "GetPlaylistItems")
+        Request(path: "/Playlists/\(playlistID)/Items", method: "GET", query: parameters.asQuery, id: "GetPlaylistItems")
     }
 
     struct GetPlaylistItemsParameters {

--- a/Sources/Paths/GetPluginConfigurationAPI.swift
+++ b/Sources/Paths/GetPluginConfigurationAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets plugin configuration.
     static func getPluginConfiguration(pluginID: String) -> Request<Void> {
-        Request(method: "GET", url: "/Plugins/\(pluginID)/Configuration", id: "GetPluginConfiguration")
+        Request(path: "/Plugins/\(pluginID)/Configuration", method: "GET", id: "GetPluginConfiguration")
     }
 }

--- a/Sources/Paths/GetPluginImageAPI.swift
+++ b/Sources/Paths/GetPluginImageAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets a plugin's image.
     static func getPluginImage(pluginID: String, version: String) -> Request<Data> {
-        Request(method: "GET", url: "/Plugins/\(pluginID)/\(version)/Image", id: "GetPluginImage")
+        Request(path: "/Plugins/\(pluginID)/\(version)/Image", method: "GET", id: "GetPluginImage")
     }
 }

--- a/Sources/Paths/GetPluginManifestAPI.swift
+++ b/Sources/Paths/GetPluginManifestAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets a plugin's manifest.
     static func getPluginManifest(pluginID: String) -> Request<Void> {
-        Request(method: "POST", url: "/Plugins/\(pluginID)/Manifest", id: "GetPluginManifest")
+        Request(path: "/Plugins/\(pluginID)/Manifest", method: "POST", id: "GetPluginManifest")
     }
 }

--- a/Sources/Paths/GetPluginsAPI.swift
+++ b/Sources/Paths/GetPluginsAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets a list of currently installed plugins.
     static var getPlugins: Request<[JellyfinAPI.PluginInfo]> {
-        Request(method: "GET", url: "/Plugins", id: "GetPlugins")
+        Request(path: "/Plugins", method: "GET", id: "GetPlugins")
     }
 }

--- a/Sources/Paths/GetPostedPlaybackInfoAPI.swift
+++ b/Sources/Paths/GetPostedPlaybackInfoAPI.swift
@@ -21,7 +21,7 @@ public extension Paths {
         parameters: GetPostedPlaybackInfoParameters? = nil,
         _ body: JellyfinAPI.PlaybackInfoDto? = nil
     ) -> Request<JellyfinAPI.PlaybackInfoResponse> {
-        Request(method: "POST", url: "/Items/\(itemID)/PlaybackInfo", query: parameters?.asQuery, body: body, id: "GetPostedPlaybackInfo")
+        Request(path: "/Items/\(itemID)/PlaybackInfo", method: "POST", query: parameters?.asQuery, body: body, id: "GetPostedPlaybackInfo")
     }
 
     struct GetPostedPlaybackInfoParameters {

--- a/Sources/Paths/GetProfileAPI.swift
+++ b/Sources/Paths/GetProfileAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets a single profile.
     static func getProfile(profileID: String) -> Request<JellyfinAPI.DeviceProfile> {
-        Request(method: "GET", url: "/Dlna/Profiles/\(profileID)", id: "GetProfile")
+        Request(path: "/Dlna/Profiles/\(profileID)", method: "GET", id: "GetProfile")
     }
 }

--- a/Sources/Paths/GetProfileInfosAPI.swift
+++ b/Sources/Paths/GetProfileInfosAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Get profile infos.
     static var getProfileInfos: Request<[JellyfinAPI.DeviceProfileInfo]> {
-        Request(method: "GET", url: "/Dlna/ProfileInfos", id: "GetProfileInfos")
+        Request(path: "/Dlna/ProfileInfos", method: "GET", id: "GetProfileInfos")
     }
 }

--- a/Sources/Paths/GetProgramAPI.swift
+++ b/Sources/Paths/GetProgramAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 extension Paths {
     /// Gets a live tv program.
     public static func getProgram(programID: String, userID: String? = nil) -> Request<JellyfinAPI.BaseItemDto> {
-        Request(method: "GET", url: "/LiveTv/Programs/\(programID)", query: makeGetProgramQuery(userID), id: "GetProgram")
+        Request(path: "/LiveTv/Programs/\(programID)", method: "GET", query: makeGetProgramQuery(userID), id: "GetProgram")
     }
 
     private static func makeGetProgramQuery(_ userID: String?) -> [(String, String?)] {

--- a/Sources/Paths/GetProgramsAPI.swift
+++ b/Sources/Paths/GetProgramsAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets available live tv epgs.
     static func getPrograms(_ body: JellyfinAPI.GetProgramsDto? = nil) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "POST", url: "/LiveTv/Programs", body: body, id: "GetPrograms")
+        Request(path: "/LiveTv/Programs", method: "POST", body: body, id: "GetPrograms")
     }
 }

--- a/Sources/Paths/GetPublicSystemInfoAPI.swift
+++ b/Sources/Paths/GetPublicSystemInfoAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets public information about the server.
     static var getPublicSystemInfo: Request<JellyfinAPI.PublicSystemInfo> {
-        Request(method: "GET", url: "/System/Info/Public", id: "GetPublicSystemInfo")
+        Request(path: "/System/Info/Public", method: "GET", id: "GetPublicSystemInfo")
     }
 }

--- a/Sources/Paths/GetPublicUsersAPI.swift
+++ b/Sources/Paths/GetPublicUsersAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets a list of publicly visible users for display on a login screen.
     static var getPublicUsers: Request<[JellyfinAPI.UserDto]> {
-        Request(method: "GET", url: "/Users/Public", id: "GetPublicUsers")
+        Request(path: "/Users/Public", method: "GET", id: "GetPublicUsers")
     }
 }

--- a/Sources/Paths/GetQueryFiltersAPI.swift
+++ b/Sources/Paths/GetQueryFiltersAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets query filters.
     static func getQueryFilters(parameters: GetQueryFiltersParameters? = nil) -> Request<JellyfinAPI.QueryFilters> {
-        Request(method: "GET", url: "/Items/Filters2", query: parameters?.asQuery, id: "GetQueryFilters")
+        Request(path: "/Items/Filters2", method: "GET", query: parameters?.asQuery, id: "GetQueryFilters")
     }
 
     struct GetQueryFiltersParameters {

--- a/Sources/Paths/GetQueryFiltersLegacyAPI.swift
+++ b/Sources/Paths/GetQueryFiltersLegacyAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets legacy query filters.
     static func getQueryFiltersLegacy(parameters: GetQueryFiltersLegacyParameters? = nil) -> Request<JellyfinAPI.QueryFiltersLegacy> {
-        Request(method: "GET", url: "/Items/Filters", query: parameters?.asQuery, id: "GetQueryFiltersLegacy")
+        Request(path: "/Items/Filters", method: "GET", query: parameters?.asQuery, id: "GetQueryFiltersLegacy")
     }
 
     struct GetQueryFiltersLegacyParameters {

--- a/Sources/Paths/GetRatingImageAPI.swift
+++ b/Sources/Paths/GetRatingImageAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Get rating image.
     static func getRatingImage(theme: String, name: String) -> Request<Data> {
-        Request(method: "GET", url: "/Images/Ratings/\(theme)/\(name)", id: "GetRatingImage")
+        Request(path: "/Images/Ratings/\(theme)/\(name)", method: "GET", id: "GetRatingImage")
     }
 }

--- a/Sources/Paths/GetRatingImagesAPI.swift
+++ b/Sources/Paths/GetRatingImagesAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Get all general images.
     static var getRatingImages: Request<[JellyfinAPI.ImageByNameInfo]> {
-        Request(method: "GET", url: "/Images/Ratings", id: "GetRatingImages")
+        Request(path: "/Images/Ratings", method: "GET", id: "GetRatingImages")
     }
 }

--- a/Sources/Paths/GetRecommendedProgramsAPI.swift
+++ b/Sources/Paths/GetRecommendedProgramsAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets recommended live tv epgs.
     static func getRecommendedPrograms(parameters: GetRecommendedProgramsParameters? = nil) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/LiveTv/Programs/Recommended", query: parameters?.asQuery, id: "GetRecommendedPrograms")
+        Request(path: "/LiveTv/Programs/Recommended", method: "GET", query: parameters?.asQuery, id: "GetRecommendedPrograms")
     }
 
     struct GetRecommendedProgramsParameters {

--- a/Sources/Paths/GetRecordingAPI.swift
+++ b/Sources/Paths/GetRecordingAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 extension Paths {
     /// Gets a live tv recording.
     public static func getRecording(recordingID: String, userID: String? = nil) -> Request<JellyfinAPI.BaseItemDto> {
-        Request(method: "GET", url: "/LiveTv/Recordings/\(recordingID)", query: makeGetRecordingQuery(userID), id: "GetRecording")
+        Request(path: "/LiveTv/Recordings/\(recordingID)", method: "GET", query: makeGetRecordingQuery(userID), id: "GetRecording")
     }
 
     private static func makeGetRecordingQuery(_ userID: String?) -> [(String, String?)] {

--- a/Sources/Paths/GetRecordingFoldersAPI.swift
+++ b/Sources/Paths/GetRecordingFoldersAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 extension Paths {
     /// Gets recording folders.
     public static func getRecordingFolders(userID: String? = nil) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/LiveTv/Recordings/Folders", query: makeGetRecordingFoldersQuery(userID), id: "GetRecordingFolders")
+        Request(path: "/LiveTv/Recordings/Folders", method: "GET", query: makeGetRecordingFoldersQuery(userID), id: "GetRecordingFolders")
     }
 
     private static func makeGetRecordingFoldersQuery(_ userID: String?) -> [(String, String?)] {

--- a/Sources/Paths/GetRecordingGroupAPI.swift
+++ b/Sources/Paths/GetRecordingGroupAPI.swift
@@ -14,6 +14,6 @@ public extension Paths {
     /// Get recording group.
     @available(*, deprecated, message: "Deprecated")
     static func getRecordingGroup(groupID: String) -> Request<Void> {
-        Request(method: "GET", url: "/LiveTv/Recordings/Groups/\(groupID)", id: "GetRecordingGroup")
+        Request(path: "/LiveTv/Recordings/Groups/\(groupID)", method: "GET", id: "GetRecordingGroup")
     }
 }

--- a/Sources/Paths/GetRecordingGroupsAPI.swift
+++ b/Sources/Paths/GetRecordingGroupsAPI.swift
@@ -14,7 +14,7 @@ extension Paths {
     /// Gets live tv recording groups.
     @available(*, deprecated, message: "Deprecated")
     public static func getRecordingGroups(userID: String? = nil) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/LiveTv/Recordings/Groups", query: makeGetRecordingGroupsQuery(userID), id: "GetRecordingGroups")
+        Request(path: "/LiveTv/Recordings/Groups", method: "GET", query: makeGetRecordingGroupsQuery(userID), id: "GetRecordingGroups")
     }
 
     private static func makeGetRecordingGroupsQuery(_ userID: String?) -> [(String, String?)] {

--- a/Sources/Paths/GetRecordingsAPI.swift
+++ b/Sources/Paths/GetRecordingsAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets live tv recordings.
     static func getRecordings(parameters: GetRecordingsParameters? = nil) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/LiveTv/Recordings", query: parameters?.asQuery, id: "GetRecordings")
+        Request(path: "/LiveTv/Recordings", method: "GET", query: parameters?.asQuery, id: "GetRecordings")
     }
 
     struct GetRecordingsParameters {

--- a/Sources/Paths/GetRecordingsSeriesAPI.swift
+++ b/Sources/Paths/GetRecordingsSeriesAPI.swift
@@ -14,7 +14,7 @@ public extension Paths {
     /// Gets live tv recording series.
     @available(*, deprecated, message: "Deprecated")
     static func getRecordingsSeries(parameters: GetRecordingsSeriesParameters? = nil) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/LiveTv/Recordings/Series", query: parameters?.asQuery, id: "GetRecordingsSeries")
+        Request(path: "/LiveTv/Recordings/Series", method: "GET", query: parameters?.asQuery, id: "GetRecordingsSeries")
     }
 
     struct GetRecordingsSeriesParameters {

--- a/Sources/Paths/GetRemoteImageProvidersAPI.swift
+++ b/Sources/Paths/GetRemoteImageProvidersAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets available remote image providers for an item.
     static func getRemoteImageProviders(itemID: String) -> Request<[JellyfinAPI.ImageProviderInfo]> {
-        Request(method: "GET", url: "/Items/\(itemID)/RemoteImages/Providers", id: "GetRemoteImageProviders")
+        Request(path: "/Items/\(itemID)/RemoteImages/Providers", method: "GET", id: "GetRemoteImageProviders")
     }
 }

--- a/Sources/Paths/GetRemoteImagesAPI.swift
+++ b/Sources/Paths/GetRemoteImagesAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets available remote images for an item.
     static func getRemoteImages(itemID: String, parameters: GetRemoteImagesParameters? = nil) -> Request<JellyfinAPI.RemoteImageResult> {
-        Request(method: "GET", url: "/Items/\(itemID)/RemoteImages", query: parameters?.asQuery, id: "GetRemoteImages")
+        Request(path: "/Items/\(itemID)/RemoteImages", method: "GET", query: parameters?.asQuery, id: "GetRemoteImages")
     }
 
     struct GetRemoteImagesParameters {

--- a/Sources/Paths/GetRemoteSubtitlesAPI.swift
+++ b/Sources/Paths/GetRemoteSubtitlesAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets the remote subtitles.
     static func getRemoteSubtitles(id: String) -> Request<String> {
-        Request(method: "GET", url: "/Providers/Subtitles/Subtitles/\(id)", id: "GetRemoteSubtitles")
+        Request(path: "/Providers/Subtitles/Subtitles/\(id)", method: "GET", id: "GetRemoteSubtitles")
     }
 }

--- a/Sources/Paths/GetRepositoriesAPI.swift
+++ b/Sources/Paths/GetRepositoriesAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets all package repositories.
     static var getRepositories: Request<[JellyfinAPI.RepositoryInfo]> {
-        Request(method: "GET", url: "/Repositories", id: "GetRepositories")
+        Request(path: "/Repositories", method: "GET", id: "GetRepositories")
     }
 }

--- a/Sources/Paths/GetResumeItemsAPI.swift
+++ b/Sources/Paths/GetResumeItemsAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets items based on a query.
     static func getResumeItems(userID: String, parameters: GetResumeItemsParameters? = nil) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/Users/\(userID)/Items/Resume", query: parameters?.asQuery, id: "GetResumeItems")
+        Request(path: "/Users/\(userID)/Items/Resume", method: "GET", query: parameters?.asQuery, id: "GetResumeItems")
     }
 
     struct GetResumeItemsParameters {

--- a/Sources/Paths/GetRootFolderAPI.swift
+++ b/Sources/Paths/GetRootFolderAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets the root folder from a user's library.
     static func getRootFolder(userID: String) -> Request<JellyfinAPI.BaseItemDto> {
-        Request(method: "GET", url: "/Users/\(userID)/Items/Root", id: "GetRootFolder")
+        Request(path: "/Users/\(userID)/Items/Root", method: "GET", id: "GetRootFolder")
     }
 }

--- a/Sources/Paths/GetSchedulesDirectCountriesAPI.swift
+++ b/Sources/Paths/GetSchedulesDirectCountriesAPI.swift
@@ -12,7 +12,7 @@ import URLQueryEncoder
 
 public extension Paths {
     /// Gets available countries.
-    static var getSchedulesDirectCountries: Request<String> {
-        Request(method: "GET", url: "/LiveTv/ListingProviders/SchedulesDirect/Countries", id: "GetSchedulesDirectCountries")
+    static var getSchedulesDirectCountries: Request<Data> {
+        Request(path: "/LiveTv/ListingProviders/SchedulesDirect/Countries", method: "GET", id: "GetSchedulesDirectCountries")
     }
 }

--- a/Sources/Paths/GetSeasonsAPI.swift
+++ b/Sources/Paths/GetSeasonsAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets seasons for a tv series.
     static func getSeasons(seriesID: String, parameters: GetSeasonsParameters? = nil) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/Shows/\(seriesID)/Seasons", query: parameters?.asQuery, id: "GetSeasons")
+        Request(path: "/Shows/\(seriesID)/Seasons", method: "GET", query: parameters?.asQuery, id: "GetSeasons")
     }
 
     struct GetSeasonsParameters {

--- a/Sources/Paths/GetSeriesRemoteSearchResultsAPI.swift
+++ b/Sources/Paths/GetSeriesRemoteSearchResultsAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Get series remote search.
     static func getSeriesRemoteSearchResults(_ body: JellyfinAPI.SeriesInfoRemoteSearchQuery) -> Request<[JellyfinAPI.RemoteSearchResult]> {
-        Request(method: "POST", url: "/Items/RemoteSearch/Series", body: body, id: "GetSeriesRemoteSearchResults")
+        Request(path: "/Items/RemoteSearch/Series", method: "POST", body: body, id: "GetSeriesRemoteSearchResults")
     }
 }

--- a/Sources/Paths/GetSeriesTimerAPI.swift
+++ b/Sources/Paths/GetSeriesTimerAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets a live tv series timer.
     static func getSeriesTimer(timerID: String) -> Request<JellyfinAPI.SeriesTimerInfoDto> {
-        Request(method: "GET", url: "/LiveTv/SeriesTimers/\(timerID)", id: "GetSeriesTimer")
+        Request(path: "/LiveTv/SeriesTimers/\(timerID)", method: "GET", id: "GetSeriesTimer")
     }
 }

--- a/Sources/Paths/GetSeriesTimersAPI.swift
+++ b/Sources/Paths/GetSeriesTimersAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets live tv series timers.
     static func getSeriesTimers(parameters: GetSeriesTimersParameters? = nil) -> Request<JellyfinAPI.SeriesTimerInfoDtoQueryResult> {
-        Request(method: "GET", url: "/LiveTv/SeriesTimers", query: parameters?.asQuery, id: "GetSeriesTimers")
+        Request(path: "/LiveTv/SeriesTimers", method: "GET", query: parameters?.asQuery, id: "GetSeriesTimers")
     }
 
     struct GetSeriesTimersParameters {

--- a/Sources/Paths/GetServerLogsAPI.swift
+++ b/Sources/Paths/GetServerLogsAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets a list of available server log files.
     static var getServerLogs: Request<[JellyfinAPI.LogFile]> {
-        Request(method: "GET", url: "/System/Logs", id: "GetServerLogs")
+        Request(path: "/System/Logs", method: "GET", id: "GetServerLogs")
     }
 }

--- a/Sources/Paths/GetSessionsAPI.swift
+++ b/Sources/Paths/GetSessionsAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets a list of sessions.
     static func getSessions(parameters: GetSessionsParameters? = nil) -> Request<[JellyfinAPI.SessionInfo]> {
-        Request(method: "GET", url: "/Sessions", query: parameters?.asQuery, id: "GetSessions")
+        Request(path: "/Sessions", method: "GET", query: parameters?.asQuery, id: "GetSessions")
     }
 
     struct GetSessionsParameters {

--- a/Sources/Paths/GetSimilarAlbumsAPI.swift
+++ b/Sources/Paths/GetSimilarAlbumsAPI.swift
@@ -16,7 +16,7 @@ public extension Paths {
         itemID: String,
         parameters: GetSimilarAlbumsParameters? = nil
     ) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/Albums/\(itemID)/Similar", query: parameters?.asQuery, id: "GetSimilarAlbums")
+        Request(path: "/Albums/\(itemID)/Similar", method: "GET", query: parameters?.asQuery, id: "GetSimilarAlbums")
     }
 
     struct GetSimilarAlbumsParameters {

--- a/Sources/Paths/GetSimilarArtistsAPI.swift
+++ b/Sources/Paths/GetSimilarArtistsAPI.swift
@@ -16,7 +16,7 @@ public extension Paths {
         itemID: String,
         parameters: GetSimilarArtistsParameters? = nil
     ) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/Artists/\(itemID)/Similar", query: parameters?.asQuery, id: "GetSimilarArtists")
+        Request(path: "/Artists/\(itemID)/Similar", method: "GET", query: parameters?.asQuery, id: "GetSimilarArtists")
     }
 
     struct GetSimilarArtistsParameters {

--- a/Sources/Paths/GetSimilarItemsAPI.swift
+++ b/Sources/Paths/GetSimilarItemsAPI.swift
@@ -16,7 +16,7 @@ public extension Paths {
         itemID: String,
         parameters: GetSimilarItemsParameters? = nil
     ) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/Items/\(itemID)/Similar", query: parameters?.asQuery, id: "GetSimilarItems")
+        Request(path: "/Items/\(itemID)/Similar", method: "GET", query: parameters?.asQuery, id: "GetSimilarItems")
     }
 
     struct GetSimilarItemsParameters {

--- a/Sources/Paths/GetSimilarMoviesAPI.swift
+++ b/Sources/Paths/GetSimilarMoviesAPI.swift
@@ -16,7 +16,7 @@ public extension Paths {
         itemID: String,
         parameters: GetSimilarMoviesParameters? = nil
     ) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/Movies/\(itemID)/Similar", query: parameters?.asQuery, id: "GetSimilarMovies")
+        Request(path: "/Movies/\(itemID)/Similar", method: "GET", query: parameters?.asQuery, id: "GetSimilarMovies")
     }
 
     struct GetSimilarMoviesParameters {

--- a/Sources/Paths/GetSimilarShowsAPI.swift
+++ b/Sources/Paths/GetSimilarShowsAPI.swift
@@ -16,7 +16,7 @@ public extension Paths {
         itemID: String,
         parameters: GetSimilarShowsParameters? = nil
     ) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/Shows/\(itemID)/Similar", query: parameters?.asQuery, id: "GetSimilarShows")
+        Request(path: "/Shows/\(itemID)/Similar", method: "GET", query: parameters?.asQuery, id: "GetSimilarShows")
     }
 
     struct GetSimilarShowsParameters {

--- a/Sources/Paths/GetSimilarTrailersAPI.swift
+++ b/Sources/Paths/GetSimilarTrailersAPI.swift
@@ -16,7 +16,7 @@ public extension Paths {
         itemID: String,
         parameters: GetSimilarTrailersParameters? = nil
     ) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/Trailers/\(itemID)/Similar", query: parameters?.asQuery, id: "GetSimilarTrailers")
+        Request(path: "/Trailers/\(itemID)/Similar", method: "GET", query: parameters?.asQuery, id: "GetSimilarTrailers")
     }
 
     struct GetSimilarTrailersParameters {

--- a/Sources/Paths/GetSpecialFeaturesAPI.swift
+++ b/Sources/Paths/GetSpecialFeaturesAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets special features for an item.
     static func getSpecialFeatures(userID: String, itemID: String) -> Request<[JellyfinAPI.BaseItemDto]> {
-        Request(method: "GET", url: "/Users/\(userID)/Items/\(itemID)/SpecialFeatures", id: "GetSpecialFeatures")
+        Request(path: "/Users/\(userID)/Items/\(itemID)/SpecialFeatures", method: "GET", id: "GetSpecialFeatures")
     }
 }

--- a/Sources/Paths/GetSplashscreenAPI.swift
+++ b/Sources/Paths/GetSplashscreenAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Generates or gets the splashscreen.
     static func getSplashscreen(parameters: GetSplashscreenParameters? = nil) -> Request<Data> {
-        Request(method: "GET", url: "/Branding/Splashscreen", query: parameters?.asQuery, id: "GetSplashscreen")
+        Request(path: "/Branding/Splashscreen", method: "GET", query: parameters?.asQuery, id: "GetSplashscreen")
     }
 
     struct GetSplashscreenParameters {

--- a/Sources/Paths/GetStartupConfigurationAPI.swift
+++ b/Sources/Paths/GetStartupConfigurationAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets the initial startup wizard configuration.
     static var getStartupConfiguration: Request<JellyfinAPI.StartupConfigurationDto> {
-        Request(method: "GET", url: "/Startup/Configuration", id: "GetStartupConfiguration")
+        Request(path: "/Startup/Configuration", method: "GET", id: "GetStartupConfiguration")
     }
 }

--- a/Sources/Paths/GetStudioAPI.swift
+++ b/Sources/Paths/GetStudioAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 extension Paths {
     /// Gets a studio by name.
     public static func getStudio(name: String, userID: String? = nil) -> Request<JellyfinAPI.BaseItemDto> {
-        Request(method: "GET", url: "/Studios/\(name)", query: makeGetStudioQuery(userID), id: "GetStudio")
+        Request(path: "/Studios/\(name)", method: "GET", query: makeGetStudioQuery(userID), id: "GetStudio")
     }
 
     private static func makeGetStudioQuery(_ userID: String?) -> [(String, String?)] {

--- a/Sources/Paths/GetStudioImageAPI.swift
+++ b/Sources/Paths/GetStudioImageAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Get studio image by name.
     static func getStudioImage(name: String, imageType: String, parameters: GetStudioImageParameters? = nil) -> Request<Data> {
-        Request(method: "GET", url: "/Studios/\(name)/Images/\(imageType)", query: parameters?.asQuery, id: "GetStudioImage")
+        Request(path: "/Studios/\(name)/Images/\(imageType)", method: "GET", query: parameters?.asQuery, id: "GetStudioImage")
     }
 
     struct GetStudioImageParameters {

--- a/Sources/Paths/GetStudioImageByIndexAPI.swift
+++ b/Sources/Paths/GetStudioImageByIndexAPI.swift
@@ -19,8 +19,8 @@ public extension Paths {
         parameters: GetStudioImageByIndexParameters? = nil
     ) -> Request<Data> {
         Request(
+            path: "/Studios/\(name)/Images/\(imageType)/\(imageIndex)",
             method: "GET",
-            url: "/Studios/\(name)/Images/\(imageType)/\(imageIndex)",
             query: parameters?.asQuery,
             id: "GetStudioImageByIndex"
         )

--- a/Sources/Paths/GetStudiosAPI.swift
+++ b/Sources/Paths/GetStudiosAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets all studios from a given item, folder, or the entire library.
     static func getStudios(parameters: GetStudiosParameters? = nil) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/Studios", query: parameters?.asQuery, id: "GetStudios")
+        Request(path: "/Studios", method: "GET", query: parameters?.asQuery, id: "GetStudios")
     }
 
     struct GetStudiosParameters {

--- a/Sources/Paths/GetSubtitleAPI.swift
+++ b/Sources/Paths/GetSubtitleAPI.swift
@@ -20,8 +20,8 @@ public extension Paths {
         parameters: GetSubtitleParameters? = nil
     ) -> Request<String> {
         Request(
+            path: "/Videos/\(routeItemID)/\(routeMediaSourceID)/Subtitles/\(routeIndex)/Stream.\(routeFormat)",
             method: "GET",
-            url: "/Videos/\(routeItemID)/\(routeMediaSourceID)/Subtitles/\(routeIndex)/Stream.\(routeFormat)",
             query: parameters?.asQuery,
             id: "GetSubtitle"
         )

--- a/Sources/Paths/GetSubtitlePlaylistAPI.swift
+++ b/Sources/Paths/GetSubtitlePlaylistAPI.swift
@@ -14,8 +14,8 @@ public extension Paths {
     /// Gets an HLS subtitle playlist.
     static func getSubtitlePlaylist(itemID: String, index: Int, mediaSourceID: String, segmentLength: Int) -> Request<Data> {
         Request(
+            path: "/Videos/\(itemID)/\(mediaSourceID)/Subtitles/\(index)/subtitles.m3u8",
             method: "GET",
-            url: "/Videos/\(itemID)/\(mediaSourceID)/Subtitles/\(index)/subtitles.m3u8",
             query: [("segmentLength", String(segmentLength))],
             id: "GetSubtitlePlaylist"
         )

--- a/Sources/Paths/GetSubtitleWithTicksAPI.swift
+++ b/Sources/Paths/GetSubtitleWithTicksAPI.swift
@@ -21,8 +21,8 @@ public extension Paths {
         parameters: GetSubtitleWithTicksParameters? = nil
     ) -> Request<String> {
         Request(
+            path: "/Videos/\(routeItemID)/\(routeMediaSourceID)/Subtitles/\(routeIndex)/\(routeStartPositionTicks)/Stream.\(routeFormat)",
             method: "GET",
-            url: "/Videos/\(routeItemID)/\(routeMediaSourceID)/Subtitles/\(routeIndex)/\(routeStartPositionTicks)/Stream.\(routeFormat)",
             query: parameters?.asQuery,
             id: "GetSubtitleWithTicks"
         )

--- a/Sources/Paths/GetSuggestionsAPI.swift
+++ b/Sources/Paths/GetSuggestionsAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets suggestions.
     static func getSuggestions(userID: String, parameters: GetSuggestionsParameters? = nil) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/Users/\(userID)/Suggestions", query: parameters?.asQuery, id: "GetSuggestions")
+        Request(path: "/Users/\(userID)/Suggestions", method: "GET", query: parameters?.asQuery, id: "GetSuggestions")
     }
 
     struct GetSuggestionsParameters {

--- a/Sources/Paths/GetSystemInfoAPI.swift
+++ b/Sources/Paths/GetSystemInfoAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets information about the server.
     static var getSystemInfo: Request<JellyfinAPI.SystemInfo> {
-        Request(method: "GET", url: "/System/Info", id: "GetSystemInfo")
+        Request(path: "/System/Info", method: "GET", id: "GetSystemInfo")
     }
 }

--- a/Sources/Paths/GetTaskAPI.swift
+++ b/Sources/Paths/GetTaskAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Get task by id.
     static func getTask(taskID: String) -> Request<JellyfinAPI.TaskInfo> {
-        Request(method: "GET", url: "/ScheduledTasks/\(taskID)", id: "GetTask")
+        Request(path: "/ScheduledTasks/\(taskID)", method: "GET", id: "GetTask")
     }
 }

--- a/Sources/Paths/GetTasksAPI.swift
+++ b/Sources/Paths/GetTasksAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 extension Paths {
     /// Get tasks.
     public static func getTasks(isHidden: Bool? = nil, isEnabled: Bool? = nil) -> Request<[JellyfinAPI.TaskInfo]> {
-        Request(method: "GET", url: "/ScheduledTasks", query: makeGetTasksQuery(isHidden, isEnabled), id: "GetTasks")
+        Request(path: "/ScheduledTasks", method: "GET", query: makeGetTasksQuery(isHidden, isEnabled), id: "GetTasks")
     }
 
     private static func makeGetTasksQuery(_ isHidden: Bool?, _ isEnabled: Bool?) -> [(String, String?)] {

--- a/Sources/Paths/GetThemeMediaAPI.swift
+++ b/Sources/Paths/GetThemeMediaAPI.swift
@@ -18,8 +18,8 @@ extension Paths {
         isInheritFromParent: Bool? = nil
     ) -> Request<JellyfinAPI.AllThemeMediaResult> {
         Request(
+            path: "/Items/\(itemID)/ThemeMedia",
             method: "GET",
-            url: "/Items/\(itemID)/ThemeMedia",
             query: makeGetThemeMediaQuery(userID, isInheritFromParent),
             id: "GetThemeMedia"
         )

--- a/Sources/Paths/GetThemeSongsAPI.swift
+++ b/Sources/Paths/GetThemeSongsAPI.swift
@@ -18,8 +18,8 @@ extension Paths {
         isInheritFromParent: Bool? = nil
     ) -> Request<JellyfinAPI.ThemeMediaResult> {
         Request(
+            path: "/Items/\(itemID)/ThemeSongs",
             method: "GET",
-            url: "/Items/\(itemID)/ThemeSongs",
             query: makeGetThemeSongsQuery(userID, isInheritFromParent),
             id: "GetThemeSongs"
         )

--- a/Sources/Paths/GetThemeVideosAPI.swift
+++ b/Sources/Paths/GetThemeVideosAPI.swift
@@ -18,8 +18,8 @@ extension Paths {
         isInheritFromParent: Bool? = nil
     ) -> Request<JellyfinAPI.ThemeMediaResult> {
         Request(
+            path: "/Items/\(itemID)/ThemeVideos",
             method: "GET",
-            url: "/Items/\(itemID)/ThemeVideos",
             query: makeGetThemeVideosQuery(userID, isInheritFromParent),
             id: "GetThemeVideos"
         )

--- a/Sources/Paths/GetTimerAPI.swift
+++ b/Sources/Paths/GetTimerAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets a timer.
     static func getTimer(timerID: String) -> Request<JellyfinAPI.TimerInfoDto> {
-        Request(method: "GET", url: "/LiveTv/Timers/\(timerID)", id: "GetTimer")
+        Request(path: "/LiveTv/Timers/\(timerID)", method: "GET", id: "GetTimer")
     }
 }

--- a/Sources/Paths/GetTimersAPI.swift
+++ b/Sources/Paths/GetTimersAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets the live tv timers.
     static func getTimers(parameters: GetTimersParameters? = nil) -> Request<JellyfinAPI.TimerInfoDtoQueryResult> {
-        Request(method: "GET", url: "/LiveTv/Timers", query: parameters?.asQuery, id: "GetTimers")
+        Request(path: "/LiveTv/Timers", method: "GET", query: parameters?.asQuery, id: "GetTimers")
     }
 
     struct GetTimersParameters {

--- a/Sources/Paths/GetTrailerRemoteSearchResultsAPI.swift
+++ b/Sources/Paths/GetTrailerRemoteSearchResultsAPI.swift
@@ -16,6 +16,6 @@ public extension Paths {
         _ body: JellyfinAPI
             .TrailerInfoRemoteSearchQuery
     ) -> Request<[JellyfinAPI.RemoteSearchResult]> {
-        Request(method: "POST", url: "/Items/RemoteSearch/Trailer", body: body, id: "GetTrailerRemoteSearchResults")
+        Request(path: "/Items/RemoteSearch/Trailer", method: "POST", body: body, id: "GetTrailerRemoteSearchResults")
     }
 }

--- a/Sources/Paths/GetTrailersAPI.swift
+++ b/Sources/Paths/GetTrailersAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Finds movies and trailers similar to a given trailer.
     static func getTrailers(parameters: GetTrailersParameters? = nil) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/Trailers", query: parameters?.asQuery, id: "GetTrailers")
+        Request(path: "/Trailers", method: "GET", query: parameters?.asQuery, id: "GetTrailers")
     }
 
     struct GetTrailersParameters {

--- a/Sources/Paths/GetTunerHostTypesAPI.swift
+++ b/Sources/Paths/GetTunerHostTypesAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Get tuner host types.
     static var getTunerHostTypes: Request<[JellyfinAPI.NameIDPair]> {
-        Request(method: "GET", url: "/LiveTv/TunerHosts/Types", id: "GetTunerHostTypes")
+        Request(path: "/LiveTv/TunerHosts/Types", method: "GET", id: "GetTunerHostTypes")
     }
 }

--- a/Sources/Paths/GetUniversalAudioStreamAPI.swift
+++ b/Sources/Paths/GetUniversalAudioStreamAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets an audio stream.
     static func getUniversalAudioStream(itemID: String, parameters: GetUniversalAudioStreamParameters? = nil) -> Request<Data> {
-        Request(method: "GET", url: "/Audio/\(itemID)/universal", query: parameters?.asQuery, id: "GetUniversalAudioStream")
+        Request(path: "/Audio/\(itemID)/universal", method: "GET", query: parameters?.asQuery, id: "GetUniversalAudioStream")
     }
 
     struct GetUniversalAudioStreamParameters {

--- a/Sources/Paths/GetUpcomingEpisodesAPI.swift
+++ b/Sources/Paths/GetUpcomingEpisodesAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets a list of upcoming episodes.
     static func getUpcomingEpisodes(parameters: GetUpcomingEpisodesParameters? = nil) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/Shows/Upcoming", query: parameters?.asQuery, id: "GetUpcomingEpisodes")
+        Request(path: "/Shows/Upcoming", method: "GET", query: parameters?.asQuery, id: "GetUpcomingEpisodes")
     }
 
     struct GetUpcomingEpisodesParameters {

--- a/Sources/Paths/GetUserByIDAPI.swift
+++ b/Sources/Paths/GetUserByIDAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets a user by Id.
     static func getUserByID(userID: String) -> Request<JellyfinAPI.UserDto> {
-        Request(method: "GET", url: "/Users/\(userID)", id: "GetUserById")
+        Request(path: "/Users/\(userID)", method: "GET", id: "GetUserById")
     }
 }

--- a/Sources/Paths/GetUserImageAPI.swift
+++ b/Sources/Paths/GetUserImageAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Get user profile image.
     static func getUserImage(userID: String, imageType: String, parameters: GetUserImageParameters? = nil) -> Request<Data> {
-        Request(method: "GET", url: "/Users/\(userID)/Images/\(imageType)", query: parameters?.asQuery, id: "GetUserImage")
+        Request(path: "/Users/\(userID)/Images/\(imageType)", method: "GET", query: parameters?.asQuery, id: "GetUserImage")
     }
 
     struct GetUserImageParameters {

--- a/Sources/Paths/GetUserImageByIndexAPI.swift
+++ b/Sources/Paths/GetUserImageByIndexAPI.swift
@@ -19,8 +19,8 @@ public extension Paths {
         parameters: GetUserImageByIndexParameters? = nil
     ) -> Request<Data> {
         Request(
+            path: "/Users/\(userID)/Images/\(imageType)/\(imageIndex)",
             method: "GET",
-            url: "/Users/\(userID)/Images/\(imageType)/\(imageIndex)",
             query: parameters?.asQuery,
             id: "GetUserImageByIndex"
         )

--- a/Sources/Paths/GetUserViewsAPI.swift
+++ b/Sources/Paths/GetUserViewsAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Get user views.
     static func getUserViews(userID: String, parameters: GetUserViewsParameters? = nil) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/Users/\(userID)/Views", query: parameters?.asQuery, id: "GetUserViews")
+        Request(path: "/Users/\(userID)/Views", method: "GET", query: parameters?.asQuery, id: "GetUserViews")
     }
 
     struct GetUserViewsParameters {

--- a/Sources/Paths/GetUsersAPI.swift
+++ b/Sources/Paths/GetUsersAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 extension Paths {
     /// Gets a list of users.
     public static func getUsers(isHidden: Bool? = nil, isDisabled: Bool? = nil) -> Request<[JellyfinAPI.UserDto]> {
-        Request(method: "GET", url: "/Users", query: makeGetUsersQuery(isHidden, isDisabled), id: "GetUsers")
+        Request(path: "/Users", method: "GET", query: makeGetUsersQuery(isHidden, isDisabled), id: "GetUsers")
     }
 
     private static func makeGetUsersQuery(_ isHidden: Bool?, _ isDisabled: Bool?) -> [(String, String?)] {

--- a/Sources/Paths/GetUtcTimeAPI.swift
+++ b/Sources/Paths/GetUtcTimeAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets the current UTC time.
     static var getUtcTime: Request<JellyfinAPI.UtcTimeResponse> {
-        Request(method: "GET", url: "/GetUtcTime", id: "GetUtcTime")
+        Request(path: "/GetUtcTime", method: "GET", id: "GetUtcTime")
     }
 }

--- a/Sources/Paths/GetVariantHlsAudioPlaylistAPI.swift
+++ b/Sources/Paths/GetVariantHlsAudioPlaylistAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets an audio stream using HTTP live streaming.
     static func getVariantHlsAudioPlaylist(itemID: String, parameters: GetVariantHlsAudioPlaylistParameters? = nil) -> Request<Data> {
-        Request(method: "GET", url: "/Audio/\(itemID)/main.m3u8", query: parameters?.asQuery, id: "GetVariantHlsAudioPlaylist")
+        Request(path: "/Audio/\(itemID)/main.m3u8", method: "GET", query: parameters?.asQuery, id: "GetVariantHlsAudioPlaylist")
     }
 
     struct GetVariantHlsAudioPlaylistParameters {

--- a/Sources/Paths/GetVariantHlsVideoPlaylistAPI.swift
+++ b/Sources/Paths/GetVariantHlsVideoPlaylistAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets a video stream using HTTP live streaming.
     static func getVariantHlsVideoPlaylist(itemID: String, parameters: GetVariantHlsVideoPlaylistParameters? = nil) -> Request<Data> {
-        Request(method: "GET", url: "/Videos/\(itemID)/main.m3u8", query: parameters?.asQuery, id: "GetVariantHlsVideoPlaylist")
+        Request(path: "/Videos/\(itemID)/main.m3u8", method: "GET", query: parameters?.asQuery, id: "GetVariantHlsVideoPlaylist")
     }
 
     struct GetVariantHlsVideoPlaylistParameters {

--- a/Sources/Paths/GetVideoStreamAPI.swift
+++ b/Sources/Paths/GetVideoStreamAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets a video stream.
     static func getVideoStream(itemID: String, parameters: GetVideoStreamParameters? = nil) -> Request<Data> {
-        Request(method: "GET", url: "/Videos/\(itemID)/stream", query: parameters?.asQuery, id: "GetVideoStream")
+        Request(path: "/Videos/\(itemID)/stream", method: "GET", query: parameters?.asQuery, id: "GetVideoStream")
     }
 
     struct GetVideoStreamParameters {

--- a/Sources/Paths/GetVideoStreamByContainerAPI.swift
+++ b/Sources/Paths/GetVideoStreamByContainerAPI.swift
@@ -17,7 +17,7 @@ public extension Paths {
         container: String,
         parameters: GetVideoStreamByContainerParameters? = nil
     ) -> Request<Data> {
-        Request(method: "GET", url: "/Videos/\(itemID)/stream.\(container)", query: parameters?.asQuery, id: "GetVideoStreamByContainer")
+        Request(path: "/Videos/\(itemID)/stream.\(container)", method: "GET", query: parameters?.asQuery, id: "GetVideoStreamByContainer")
     }
 
     struct GetVideoStreamByContainerParameters {

--- a/Sources/Paths/GetVirtualFoldersAPI.swift
+++ b/Sources/Paths/GetVirtualFoldersAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets all virtual folders.
     static var getVirtualFolders: Request<[JellyfinAPI.VirtualFolderInfo]> {
-        Request(method: "GET", url: "/Library/VirtualFolders", id: "GetVirtualFolders")
+        Request(path: "/Library/VirtualFolders", method: "GET", id: "GetVirtualFolders")
     }
 }

--- a/Sources/Paths/GetWakeOnLanInfoAPI.swift
+++ b/Sources/Paths/GetWakeOnLanInfoAPI.swift
@@ -14,6 +14,6 @@ public extension Paths {
     /// Gets wake on lan information.
     @available(*, deprecated, message: "Deprecated")
     static var getWakeOnLanInfo: Request<[JellyfinAPI.WakeOnLanInfo]> {
-        Request(method: "GET", url: "/System/WakeOnLanInfo", id: "GetWakeOnLanInfo")
+        Request(path: "/System/WakeOnLanInfo", method: "GET", id: "GetWakeOnLanInfo")
     }
 }

--- a/Sources/Paths/GetYearAPI.swift
+++ b/Sources/Paths/GetYearAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 extension Paths {
     /// Gets a year.
     public static func getYear(year: Int, userID: String? = nil) -> Request<JellyfinAPI.BaseItemDto> {
-        Request(method: "GET", url: "/Years/\(year)", query: makeGetYearQuery(userID), id: "GetYear")
+        Request(path: "/Years/\(year)", method: "GET", query: makeGetYearQuery(userID), id: "GetYear")
     }
 
     private static func makeGetYearQuery(_ userID: String?) -> [(String, String?)] {

--- a/Sources/Paths/GetYearsAPI.swift
+++ b/Sources/Paths/GetYearsAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Get years.
     static func getYears(parameters: GetYearsParameters? = nil) -> Request<JellyfinAPI.BaseItemDtoQueryResult> {
-        Request(method: "GET", url: "/Years", query: parameters?.asQuery, id: "GetYears")
+        Request(path: "/Years", method: "GET", query: parameters?.asQuery, id: "GetYears")
     }
 
     struct GetYearsParameters {

--- a/Sources/Paths/HeadArtistImageAPI.swift
+++ b/Sources/Paths/HeadArtistImageAPI.swift
@@ -19,8 +19,8 @@ public extension Paths {
         parameters: HeadArtistImageParameters? = nil
     ) -> Request<Data> {
         Request(
+            path: "/Artists/\(name)/Images/\(imageType)/\(imageIndex)",
             method: "HEAD",
-            url: "/Artists/\(name)/Images/\(imageType)/\(imageIndex)",
             query: parameters?.asQuery,
             id: "HeadArtistImage"
         )

--- a/Sources/Paths/HeadAudioStreamAPI.swift
+++ b/Sources/Paths/HeadAudioStreamAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets an audio stream.
     static func headAudioStream(itemID: String, parameters: HeadAudioStreamParameters? = nil) -> Request<Data> {
-        Request(method: "HEAD", url: "/Audio/\(itemID)/stream", query: parameters?.asQuery, id: "HeadAudioStream")
+        Request(path: "/Audio/\(itemID)/stream", method: "HEAD", query: parameters?.asQuery, id: "HeadAudioStream")
     }
 
     struct HeadAudioStreamParameters {

--- a/Sources/Paths/HeadAudioStreamByContainerAPI.swift
+++ b/Sources/Paths/HeadAudioStreamByContainerAPI.swift
@@ -17,7 +17,7 @@ public extension Paths {
         container: String,
         parameters: HeadAudioStreamByContainerParameters? = nil
     ) -> Request<Data> {
-        Request(method: "HEAD", url: "/Audio/\(itemID)/stream.\(container)", query: parameters?.asQuery, id: "HeadAudioStreamByContainer")
+        Request(path: "/Audio/\(itemID)/stream.\(container)", method: "HEAD", query: parameters?.asQuery, id: "HeadAudioStreamByContainer")
     }
 
     struct HeadAudioStreamByContainerParameters {

--- a/Sources/Paths/HeadGenreImageAPI.swift
+++ b/Sources/Paths/HeadGenreImageAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Get genre image by name.
     static func headGenreImage(name: String, imageType: String, parameters: HeadGenreImageParameters? = nil) -> Request<Data> {
-        Request(method: "HEAD", url: "/Genres/\(name)/Images/\(imageType)", query: parameters?.asQuery, id: "HeadGenreImage")
+        Request(path: "/Genres/\(name)/Images/\(imageType)", method: "HEAD", query: parameters?.asQuery, id: "HeadGenreImage")
     }
 
     struct HeadGenreImageParameters {

--- a/Sources/Paths/HeadGenreImageByIndexAPI.swift
+++ b/Sources/Paths/HeadGenreImageByIndexAPI.swift
@@ -19,8 +19,8 @@ public extension Paths {
         parameters: HeadGenreImageByIndexParameters? = nil
     ) -> Request<Data> {
         Request(
+            path: "/Genres/\(name)/Images/\(imageType)/\(imageIndex)",
             method: "HEAD",
-            url: "/Genres/\(name)/Images/\(imageType)/\(imageIndex)",
             query: parameters?.asQuery,
             id: "HeadGenreImageByIndex"
         )

--- a/Sources/Paths/HeadItemImage2API.swift
+++ b/Sources/Paths/HeadItemImage2API.swift
@@ -25,8 +25,8 @@ public extension Paths {
         parameters: HeadItemImage2Parameters? = nil
     ) -> Request<Data> {
         Request(
+            path: "/Items/\(itemID)/Images/\(imageType)/\(imageIndex)/\(tag)/\(format)/\(maxWidth)/\(maxHeight)/\(percentPlayed)/\(unplayedCount)",
             method: "HEAD",
-            url: "/Items/\(itemID)/Images/\(imageType)/\(imageIndex)/\(tag)/\(format)/\(maxWidth)/\(maxHeight)/\(percentPlayed)/\(unplayedCount)",
             query: parameters?.asQuery,
             id: "HeadItemImage2"
         )

--- a/Sources/Paths/HeadItemImageAPI.swift
+++ b/Sources/Paths/HeadItemImageAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets the item's image.
     static func headItemImage(itemID: String, imageType: String, parameters: HeadItemImageParameters? = nil) -> Request<Data> {
-        Request(method: "HEAD", url: "/Items/\(itemID)/Images/\(imageType)", query: parameters?.asQuery, id: "HeadItemImage")
+        Request(path: "/Items/\(itemID)/Images/\(imageType)", method: "HEAD", query: parameters?.asQuery, id: "HeadItemImage")
     }
 
     struct HeadItemImageParameters {

--- a/Sources/Paths/HeadItemImageByIndexAPI.swift
+++ b/Sources/Paths/HeadItemImageByIndexAPI.swift
@@ -19,8 +19,8 @@ public extension Paths {
         parameters: HeadItemImageByIndexParameters? = nil
     ) -> Request<Data> {
         Request(
+            path: "/Items/\(itemID)/Images/\(imageType)/\(imageIndex)",
             method: "HEAD",
-            url: "/Items/\(itemID)/Images/\(imageType)/\(imageIndex)",
             query: parameters?.asQuery,
             id: "HeadItemImageByIndex"
         )

--- a/Sources/Paths/HeadMasterHlsAudioPlaylistAPI.swift
+++ b/Sources/Paths/HeadMasterHlsAudioPlaylistAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets an audio hls playlist stream.
     static func headMasterHlsAudioPlaylist(itemID: String, parameters: HeadMasterHlsAudioPlaylistParameters) -> Request<Data> {
-        Request(method: "HEAD", url: "/Audio/\(itemID)/master.m3u8", query: parameters.asQuery, id: "HeadMasterHlsAudioPlaylist")
+        Request(path: "/Audio/\(itemID)/master.m3u8", method: "HEAD", query: parameters.asQuery, id: "HeadMasterHlsAudioPlaylist")
     }
 
     struct HeadMasterHlsAudioPlaylistParameters {

--- a/Sources/Paths/HeadMasterHlsVideoPlaylistAPI.swift
+++ b/Sources/Paths/HeadMasterHlsVideoPlaylistAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets a video hls playlist stream.
     static func headMasterHlsVideoPlaylist(itemID: String, parameters: HeadMasterHlsVideoPlaylistParameters) -> Request<Data> {
-        Request(method: "HEAD", url: "/Videos/\(itemID)/master.m3u8", query: parameters.asQuery, id: "HeadMasterHlsVideoPlaylist")
+        Request(path: "/Videos/\(itemID)/master.m3u8", method: "HEAD", query: parameters.asQuery, id: "HeadMasterHlsVideoPlaylist")
     }
 
     struct HeadMasterHlsVideoPlaylistParameters {

--- a/Sources/Paths/HeadMusicGenreImageAPI.swift
+++ b/Sources/Paths/HeadMusicGenreImageAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Get music genre image by name.
     static func headMusicGenreImage(name: String, imageType: String, parameters: HeadMusicGenreImageParameters? = nil) -> Request<Data> {
-        Request(method: "HEAD", url: "/MusicGenres/\(name)/Images/\(imageType)", query: parameters?.asQuery, id: "HeadMusicGenreImage")
+        Request(path: "/MusicGenres/\(name)/Images/\(imageType)", method: "HEAD", query: parameters?.asQuery, id: "HeadMusicGenreImage")
     }
 
     struct HeadMusicGenreImageParameters {

--- a/Sources/Paths/HeadMusicGenreImageByIndexAPI.swift
+++ b/Sources/Paths/HeadMusicGenreImageByIndexAPI.swift
@@ -19,8 +19,8 @@ public extension Paths {
         parameters: HeadMusicGenreImageByIndexParameters? = nil
     ) -> Request<Data> {
         Request(
+            path: "/MusicGenres/\(name)/Images/\(imageType)/\(imageIndex)",
             method: "HEAD",
-            url: "/MusicGenres/\(name)/Images/\(imageType)/\(imageIndex)",
             query: parameters?.asQuery,
             id: "HeadMusicGenreImageByIndex"
         )

--- a/Sources/Paths/HeadPersonImageAPI.swift
+++ b/Sources/Paths/HeadPersonImageAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Get person image by name.
     static func headPersonImage(name: String, imageType: String, parameters: HeadPersonImageParameters? = nil) -> Request<Data> {
-        Request(method: "HEAD", url: "/Persons/\(name)/Images/\(imageType)", query: parameters?.asQuery, id: "HeadPersonImage")
+        Request(path: "/Persons/\(name)/Images/\(imageType)", method: "HEAD", query: parameters?.asQuery, id: "HeadPersonImage")
     }
 
     struct HeadPersonImageParameters {

--- a/Sources/Paths/HeadPersonImageByIndexAPI.swift
+++ b/Sources/Paths/HeadPersonImageByIndexAPI.swift
@@ -19,8 +19,8 @@ public extension Paths {
         parameters: HeadPersonImageByIndexParameters? = nil
     ) -> Request<Data> {
         Request(
+            path: "/Persons/\(name)/Images/\(imageType)/\(imageIndex)",
             method: "HEAD",
-            url: "/Persons/\(name)/Images/\(imageType)/\(imageIndex)",
             query: parameters?.asQuery,
             id: "HeadPersonImageByIndex"
         )

--- a/Sources/Paths/HeadStudioImageAPI.swift
+++ b/Sources/Paths/HeadStudioImageAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Get studio image by name.
     static func headStudioImage(name: String, imageType: String, parameters: HeadStudioImageParameters? = nil) -> Request<Data> {
-        Request(method: "HEAD", url: "/Studios/\(name)/Images/\(imageType)", query: parameters?.asQuery, id: "HeadStudioImage")
+        Request(path: "/Studios/\(name)/Images/\(imageType)", method: "HEAD", query: parameters?.asQuery, id: "HeadStudioImage")
     }
 
     struct HeadStudioImageParameters {

--- a/Sources/Paths/HeadStudioImageByIndexAPI.swift
+++ b/Sources/Paths/HeadStudioImageByIndexAPI.swift
@@ -19,8 +19,8 @@ public extension Paths {
         parameters: HeadStudioImageByIndexParameters? = nil
     ) -> Request<Data> {
         Request(
+            path: "/Studios/\(name)/Images/\(imageType)/\(imageIndex)",
             method: "HEAD",
-            url: "/Studios/\(name)/Images/\(imageType)/\(imageIndex)",
             query: parameters?.asQuery,
             id: "HeadStudioImageByIndex"
         )

--- a/Sources/Paths/HeadUniversalAudioStreamAPI.swift
+++ b/Sources/Paths/HeadUniversalAudioStreamAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets an audio stream.
     static func headUniversalAudioStream(itemID: String, parameters: HeadUniversalAudioStreamParameters? = nil) -> Request<Data> {
-        Request(method: "HEAD", url: "/Audio/\(itemID)/universal", query: parameters?.asQuery, id: "HeadUniversalAudioStream")
+        Request(path: "/Audio/\(itemID)/universal", method: "HEAD", query: parameters?.asQuery, id: "HeadUniversalAudioStream")
     }
 
     struct HeadUniversalAudioStreamParameters {

--- a/Sources/Paths/HeadUserImageAPI.swift
+++ b/Sources/Paths/HeadUserImageAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Get user profile image.
     static func headUserImage(userID: String, imageType: String, parameters: HeadUserImageParameters? = nil) -> Request<Data> {
-        Request(method: "HEAD", url: "/Users/\(userID)/Images/\(imageType)", query: parameters?.asQuery, id: "HeadUserImage")
+        Request(path: "/Users/\(userID)/Images/\(imageType)", method: "HEAD", query: parameters?.asQuery, id: "HeadUserImage")
     }
 
     struct HeadUserImageParameters {

--- a/Sources/Paths/HeadUserImageByIndexAPI.swift
+++ b/Sources/Paths/HeadUserImageByIndexAPI.swift
@@ -19,8 +19,8 @@ public extension Paths {
         parameters: HeadUserImageByIndexParameters? = nil
     ) -> Request<Data> {
         Request(
+            path: "/Users/\(userID)/Images/\(imageType)/\(imageIndex)",
             method: "HEAD",
-            url: "/Users/\(userID)/Images/\(imageType)/\(imageIndex)",
             query: parameters?.asQuery,
             id: "HeadUserImageByIndex"
         )

--- a/Sources/Paths/HeadVideoStreamAPI.swift
+++ b/Sources/Paths/HeadVideoStreamAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets a video stream.
     static func headVideoStream(itemID: String, parameters: HeadVideoStreamParameters? = nil) -> Request<Data> {
-        Request(method: "HEAD", url: "/Videos/\(itemID)/stream", query: parameters?.asQuery, id: "HeadVideoStream")
+        Request(path: "/Videos/\(itemID)/stream", method: "HEAD", query: parameters?.asQuery, id: "HeadVideoStream")
     }
 
     struct HeadVideoStreamParameters {

--- a/Sources/Paths/HeadVideoStreamByContainerAPI.swift
+++ b/Sources/Paths/HeadVideoStreamByContainerAPI.swift
@@ -17,7 +17,7 @@ public extension Paths {
         container: String,
         parameters: HeadVideoStreamByContainerParameters? = nil
     ) -> Request<Data> {
-        Request(method: "HEAD", url: "/Videos/\(itemID)/stream.\(container)", query: parameters?.asQuery, id: "HeadVideoStreamByContainer")
+        Request(path: "/Videos/\(itemID)/stream.\(container)", method: "HEAD", query: parameters?.asQuery, id: "HeadVideoStreamByContainer")
     }
 
     struct HeadVideoStreamByContainerParameters {

--- a/Sources/Paths/InitiateAPI.swift
+++ b/Sources/Paths/InitiateAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Initiate a new quick connect request.
     static var initiate: Request<JellyfinAPI.QuickConnectResult> {
-        Request(method: "GET", url: "/QuickConnect/Initiate", id: "Initiate")
+        Request(path: "/QuickConnect/Initiate", method: "GET", id: "Initiate")
     }
 }

--- a/Sources/Paths/InstallPackageAPI.swift
+++ b/Sources/Paths/InstallPackageAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Installs a package.
     static func installPackage(name: String, parameters: InstallPackageParameters? = nil) -> Request<Void> {
-        Request(method: "POST", url: "/Packages/Installed/\(name)", query: parameters?.asQuery, id: "InstallPackage")
+        Request(path: "/Packages/Installed/\(name)", method: "POST", query: parameters?.asQuery, id: "InstallPackage")
     }
 
     struct InstallPackageParameters {

--- a/Sources/Paths/LogFileAPI.swift
+++ b/Sources/Paths/LogFileAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Upload a document.
     static func logFile(_ body: String? = nil) -> Request<JellyfinAPI.ClientLogDocumentResponseDto> {
-        Request(method: "POST", url: "/ClientLog/Document", body: body, id: "LogFile")
+        Request(path: "/ClientLog/Document", method: "POST", body: body, id: "LogFile")
     }
 }

--- a/Sources/Paths/MarkFavoriteItemAPI.swift
+++ b/Sources/Paths/MarkFavoriteItemAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Marks an item as a favorite.
     static func markFavoriteItem(userID: String, itemID: String) -> Request<JellyfinAPI.UserItemDataDto> {
-        Request(method: "POST", url: "/Users/\(userID)/FavoriteItems/\(itemID)", id: "MarkFavoriteItem")
+        Request(path: "/Users/\(userID)/FavoriteItems/\(itemID)", method: "POST", id: "MarkFavoriteItem")
     }
 }

--- a/Sources/Paths/MarkPlayedItemAPI.swift
+++ b/Sources/Paths/MarkPlayedItemAPI.swift
@@ -14,8 +14,8 @@ extension Paths {
     /// Marks an item as played for user.
     public static func markPlayedItem(userID: String, itemID: String, datePlayed: Date? = nil) -> Request<JellyfinAPI.UserItemDataDto> {
         Request(
+            path: "/Users/\(userID)/PlayedItems/\(itemID)",
             method: "POST",
-            url: "/Users/\(userID)/PlayedItems/\(itemID)",
             query: makeMarkPlayedItemQuery(datePlayed),
             id: "MarkPlayedItem"
         )

--- a/Sources/Paths/MarkUnplayedItemAPI.swift
+++ b/Sources/Paths/MarkUnplayedItemAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Marks an item as unplayed for user.
     static func markUnplayedItem(userID: String, itemID: String) -> Request<JellyfinAPI.UserItemDataDto> {
-        Request(method: "DELETE", url: "/Users/\(userID)/PlayedItems/\(itemID)", id: "MarkUnplayedItem")
+        Request(path: "/Users/\(userID)/PlayedItems/\(itemID)", method: "DELETE", id: "MarkUnplayedItem")
     }
 }

--- a/Sources/Paths/MergeVersionsAPI.swift
+++ b/Sources/Paths/MergeVersionsAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 extension Paths {
     /// Merges videos into a single record.
     public static func mergeVersions(ids: [String]) -> Request<Void> {
-        Request(method: "POST", url: "/Videos/MergeVersions", query: makeMergeVersionsQuery(ids), id: "MergeVersions")
+        Request(path: "/Videos/MergeVersions", method: "POST", query: makeMergeVersionsQuery(ids), id: "MergeVersions")
     }
 
     private static func makeMergeVersionsQuery(_ ids: [String]) -> [(String, String?)] {

--- a/Sources/Paths/MoveItemAPI.swift
+++ b/Sources/Paths/MoveItemAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Moves a playlist item.
     static func moveItem(playlistID: String, itemID: String, newIndex: Int) -> Request<Void> {
-        Request(method: "POST", url: "/Playlists/\(playlistID)/Items/\(itemID)/Move/\(newIndex)", id: "MoveItem")
+        Request(path: "/Playlists/\(playlistID)/Items/\(itemID)/Move/\(newIndex)", method: "POST", id: "MoveItem")
     }
 }

--- a/Sources/Paths/OnPlaybackProgressAPI.swift
+++ b/Sources/Paths/OnPlaybackProgressAPI.swift
@@ -14,8 +14,8 @@ public extension Paths {
     /// Reports a user's playback progress.
     static func onPlaybackProgress(userID: String, itemID: String, parameters: OnPlaybackProgressParameters? = nil) -> Request<Void> {
         Request(
+            path: "/Users/\(userID)/PlayingItems/\(itemID)/Progress",
             method: "POST",
-            url: "/Users/\(userID)/PlayingItems/\(itemID)/Progress",
             query: parameters?.asQuery,
             id: "OnPlaybackProgress"
         )

--- a/Sources/Paths/OnPlaybackStartAPI.swift
+++ b/Sources/Paths/OnPlaybackStartAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Reports that a user has begun playing an item.
     static func onPlaybackStart(userID: String, itemID: String, parameters: OnPlaybackStartParameters? = nil) -> Request<Void> {
-        Request(method: "POST", url: "/Users/\(userID)/PlayingItems/\(itemID)", query: parameters?.asQuery, id: "OnPlaybackStart")
+        Request(path: "/Users/\(userID)/PlayingItems/\(itemID)", method: "POST", query: parameters?.asQuery, id: "OnPlaybackStart")
     }
 
     struct OnPlaybackStartParameters {

--- a/Sources/Paths/OnPlaybackStoppedAPI.swift
+++ b/Sources/Paths/OnPlaybackStoppedAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Reports that a user has stopped playing an item.
     static func onPlaybackStopped(userID: String, itemID: String, parameters: OnPlaybackStoppedParameters? = nil) -> Request<Void> {
-        Request(method: "DELETE", url: "/Users/\(userID)/PlayingItems/\(itemID)", query: parameters?.asQuery, id: "OnPlaybackStopped")
+        Request(path: "/Users/\(userID)/PlayingItems/\(itemID)", method: "DELETE", query: parameters?.asQuery, id: "OnPlaybackStopped")
     }
 
     struct OnPlaybackStoppedParameters {

--- a/Sources/Paths/OpenLiveStreamAPI.swift
+++ b/Sources/Paths/OpenLiveStreamAPI.swift
@@ -16,7 +16,7 @@ public extension Paths {
         parameters: OpenLiveStreamParameters? = nil,
         _ body: JellyfinAPI.OpenLiveStreamDto? = nil
     ) -> Request<JellyfinAPI.LiveStreamResponse> {
-        Request(method: "POST", url: "/LiveStreams/Open", query: parameters?.asQuery, body: body, id: "OpenLiveStream")
+        Request(path: "/LiveStreams/Open", method: "POST", query: parameters?.asQuery, body: body, id: "OpenLiveStream")
     }
 
     struct OpenLiveStreamParameters {

--- a/Sources/Paths/PingPlaybackSessionAPI.swift
+++ b/Sources/Paths/PingPlaybackSessionAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Pings a playback session.
     static func pingPlaybackSession(playSessionID: String) -> Request<Void> {
-        Request(method: "POST", url: "/Sessions/Playing/Ping", query: [("playSessionId", playSessionID)], id: "PingPlaybackSession")
+        Request(path: "/Sessions/Playing/Ping", method: "POST", query: [("playSessionId", playSessionID)], id: "PingPlaybackSession")
     }
 }

--- a/Sources/Paths/PlayAPI.swift
+++ b/Sources/Paths/PlayAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Instructs a session to play an item.
     static func play(sessionID: String, parameters: PlayParameters) -> Request<Void> {
-        Request(method: "POST", url: "/Sessions/\(sessionID)/Playing", query: parameters.asQuery, id: "Play")
+        Request(path: "/Sessions/\(sessionID)/Playing", method: "POST", query: parameters.asQuery, id: "Play")
     }
 
     struct PlayParameters {

--- a/Sources/Paths/PostAddedMoviesAPI.swift
+++ b/Sources/Paths/PostAddedMoviesAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 extension Paths {
     /// Reports that new movies have been added by an external source.
     public static func postAddedMovies(tmdbID: String? = nil, imdbID: String? = nil) -> Request<Void> {
-        Request(method: "POST", url: "/Library/Movies/Added", query: makePostAddedMoviesQuery(tmdbID, imdbID), id: "PostAddedMovies")
+        Request(path: "/Library/Movies/Added", method: "POST", query: makePostAddedMoviesQuery(tmdbID, imdbID), id: "PostAddedMovies")
     }
 
     private static func makePostAddedMoviesQuery(_ tmdbID: String?, _ imdbID: String?) -> [(String, String?)] {

--- a/Sources/Paths/PostAddedSeriesAPI.swift
+++ b/Sources/Paths/PostAddedSeriesAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 extension Paths {
     /// Reports that new episodes of a series have been added by an external source.
     public static func postAddedSeries(tvdbID: String? = nil) -> Request<Void> {
-        Request(method: "POST", url: "/Library/Series/Added", query: makePostAddedSeriesQuery(tvdbID), id: "PostAddedSeries")
+        Request(path: "/Library/Series/Added", method: "POST", query: makePostAddedSeriesQuery(tvdbID), id: "PostAddedSeries")
     }
 
     private static func makePostAddedSeriesQuery(_ tvdbID: String?) -> [(String, String?)] {

--- a/Sources/Paths/PostCapabilitiesAPI.swift
+++ b/Sources/Paths/PostCapabilitiesAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Updates capabilities for a device.
     static func postCapabilities(parameters: PostCapabilitiesParameters? = nil) -> Request<Void> {
-        Request(method: "POST", url: "/Sessions/Capabilities", query: parameters?.asQuery, id: "PostCapabilities")
+        Request(path: "/Sessions/Capabilities", method: "POST", query: parameters?.asQuery, id: "PostCapabilities")
     }
 
     struct PostCapabilitiesParameters {

--- a/Sources/Paths/PostFullCapabilitiesAPI.swift
+++ b/Sources/Paths/PostFullCapabilitiesAPI.swift
@@ -14,8 +14,8 @@ extension Paths {
     /// Updates capabilities for a device.
     public static func postFullCapabilities(id: String? = nil, _ body: JellyfinAPI.ClientCapabilitiesDto) -> Request<Void> {
         Request(
+            path: "/Sessions/Capabilities/Full",
             method: "POST",
-            url: "/Sessions/Capabilities/Full",
             query: makePostFullCapabilitiesQuery(id),
             body: body,
             id: "PostFullCapabilities"

--- a/Sources/Paths/PostPingSystemAPI.swift
+++ b/Sources/Paths/PostPingSystemAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Pings the system.
     static var postPingSystem: Request<String> {
-        Request(method: "POST", url: "/System/Ping", id: "PostPingSystem")
+        Request(path: "/System/Ping", method: "POST", id: "PostPingSystem")
     }
 }

--- a/Sources/Paths/PostUpdatedMediaAPI.swift
+++ b/Sources/Paths/PostUpdatedMediaAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Reports that new movies have been added by an external source.
     static func postUpdatedMedia(_ body: JellyfinAPI.MediaUpdateInfoDto) -> Request<Void> {
-        Request(method: "POST", url: "/Library/Media/Updated", body: body, id: "PostUpdatedMedia")
+        Request(path: "/Library/Media/Updated", method: "POST", body: body, id: "PostUpdatedMedia")
     }
 }

--- a/Sources/Paths/PostUpdatedMoviesAPI.swift
+++ b/Sources/Paths/PostUpdatedMoviesAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 extension Paths {
     /// Reports that new movies have been added by an external source.
     public static func postUpdatedMovies(tmdbID: String? = nil, imdbID: String? = nil) -> Request<Void> {
-        Request(method: "POST", url: "/Library/Movies/Updated", query: makePostUpdatedMoviesQuery(tmdbID, imdbID), id: "PostUpdatedMovies")
+        Request(path: "/Library/Movies/Updated", method: "POST", query: makePostUpdatedMoviesQuery(tmdbID, imdbID), id: "PostUpdatedMovies")
     }
 
     private static func makePostUpdatedMoviesQuery(_ tmdbID: String?, _ imdbID: String?) -> [(String, String?)] {

--- a/Sources/Paths/PostUpdatedSeriesAPI.swift
+++ b/Sources/Paths/PostUpdatedSeriesAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 extension Paths {
     /// Reports that new episodes of a series have been added by an external source.
     public static func postUpdatedSeries(tvdbID: String? = nil) -> Request<Void> {
-        Request(method: "POST", url: "/Library/Series/Updated", query: makePostUpdatedSeriesQuery(tvdbID), id: "PostUpdatedSeries")
+        Request(path: "/Library/Series/Updated", method: "POST", query: makePostUpdatedSeriesQuery(tvdbID), id: "PostUpdatedSeries")
     }
 
     private static func makePostUpdatedSeriesQuery(_ tvdbID: String?) -> [(String, String?)] {

--- a/Sources/Paths/PostUserImageAPI.swift
+++ b/Sources/Paths/PostUserImageAPI.swift
@@ -14,8 +14,8 @@ extension Paths {
     /// Sets the user image.
     public static func postUserImage(userID: String, imageType: String, index: Int? = nil, _ body: Data? = nil) -> Request<Void> {
         Request(
+            path: "/Users/\(userID)/Images/\(imageType)",
             method: "POST",
-            url: "/Users/\(userID)/Images/\(imageType)",
             query: makePostUserImageQuery(index),
             body: body,
             id: "PostUserImage"

--- a/Sources/Paths/PostUserImageByIndexAPI.swift
+++ b/Sources/Paths/PostUserImageByIndexAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Sets the user image.
     static func postUserImageByIndex(userID: String, imageType: String, index: Int, _ body: Data? = nil) -> Request<Void> {
-        Request(method: "POST", url: "/Users/\(userID)/Images/\(imageType)/\(index)", body: body, id: "PostUserImageByIndex")
+        Request(path: "/Users/\(userID)/Images/\(imageType)/\(index)", method: "POST", body: body, id: "PostUserImageByIndex")
     }
 }

--- a/Sources/Paths/ProcessConnectionManagerControlRequestAPI.swift
+++ b/Sources/Paths/ProcessConnectionManagerControlRequestAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Process a connection manager control request.
     static func processConnectionManagerControlRequest(serverID: String) -> Request<String> {
-        Request(method: "POST", url: "/Dlna/\(serverID)/ConnectionManager/Control", id: "ProcessConnectionManagerControlRequest")
+        Request(path: "/Dlna/\(serverID)/ConnectionManager/Control", method: "POST", id: "ProcessConnectionManagerControlRequest")
     }
 }

--- a/Sources/Paths/ProcessContentDirectoryControlRequestAPI.swift
+++ b/Sources/Paths/ProcessContentDirectoryControlRequestAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Process a content directory control request.
     static func processContentDirectoryControlRequest(serverID: String) -> Request<String> {
-        Request(method: "POST", url: "/Dlna/\(serverID)/ContentDirectory/Control", id: "ProcessContentDirectoryControlRequest")
+        Request(path: "/Dlna/\(serverID)/ContentDirectory/Control", method: "POST", id: "ProcessContentDirectoryControlRequest")
     }
 }

--- a/Sources/Paths/ProcessMediaReceiverRegistrarControlRequestAPI.swift
+++ b/Sources/Paths/ProcessMediaReceiverRegistrarControlRequestAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Process a media receiver registrar control request.
     static func processMediaReceiverRegistrarControlRequest(serverID: String) -> Request<String> {
-        Request(method: "POST", url: "/Dlna/\(serverID)/MediaReceiverRegistrar/Control", id: "ProcessMediaReceiverRegistrarControlRequest")
+        Request(path: "/Dlna/\(serverID)/MediaReceiverRegistrar/Control", method: "POST", id: "ProcessMediaReceiverRegistrarControlRequest")
     }
 }

--- a/Sources/Paths/RefreshItemAPI.swift
+++ b/Sources/Paths/RefreshItemAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Refreshes metadata for an item.
     static func refreshItem(itemID: String, parameters: RefreshItemParameters? = nil) -> Request<Void> {
-        Request(method: "POST", url: "/Items/\(itemID)/Refresh", query: parameters?.asQuery, id: "RefreshItem")
+        Request(path: "/Items/\(itemID)/Refresh", method: "POST", query: parameters?.asQuery, id: "RefreshItem")
     }
 
     struct RefreshItemParameters {

--- a/Sources/Paths/RefreshLibraryAPI.swift
+++ b/Sources/Paths/RefreshLibraryAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Starts a library scan.
     static var refreshLibrary: Request<Void> {
-        Request(method: "POST", url: "/Library/Refresh", id: "RefreshLibrary")
+        Request(path: "/Library/Refresh", method: "POST", id: "RefreshLibrary")
     }
 }

--- a/Sources/Paths/RemoveFromCollectionAPI.swift
+++ b/Sources/Paths/RemoveFromCollectionAPI.swift
@@ -14,8 +14,8 @@ extension Paths {
     /// Removes items from a collection.
     public static func removeFromCollection(collectionID: String, ids: [String]) -> Request<Void> {
         Request(
+            path: "/Collections/\(collectionID)/Items",
             method: "DELETE",
-            url: "/Collections/\(collectionID)/Items",
             query: makeRemoveFromCollectionQuery(ids),
             id: "RemoveFromCollection"
         )

--- a/Sources/Paths/RemoveFromPlaylistAPI.swift
+++ b/Sources/Paths/RemoveFromPlaylistAPI.swift
@@ -14,8 +14,8 @@ extension Paths {
     /// Removes items from a playlist.
     public static func removeFromPlaylist(playlistID: String, entryIDs: [String]? = nil) -> Request<Void> {
         Request(
+            path: "/Playlists/\(playlistID)/Items",
             method: "DELETE",
-            url: "/Playlists/\(playlistID)/Items",
             query: makeRemoveFromPlaylistQuery(entryIDs),
             id: "RemoveFromPlaylist"
         )

--- a/Sources/Paths/RemoveMediaPathAPI.swift
+++ b/Sources/Paths/RemoveMediaPathAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Remove a media path.
     static func removeMediaPath(parameters: RemoveMediaPathParameters? = nil) -> Request<Void> {
-        Request(method: "DELETE", url: "/Library/VirtualFolders/Paths", query: parameters?.asQuery, id: "RemoveMediaPath")
+        Request(path: "/Library/VirtualFolders/Paths", method: "DELETE", query: parameters?.asQuery, id: "RemoveMediaPath")
     }
 
     struct RemoveMediaPathParameters {

--- a/Sources/Paths/RemoveUserFromSessionAPI.swift
+++ b/Sources/Paths/RemoveUserFromSessionAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Removes an additional user from a session.
     static func removeUserFromSession(sessionID: String, userID: String) -> Request<Void> {
-        Request(method: "DELETE", url: "/Sessions/\(sessionID)/User/\(userID)", id: "RemoveUserFromSession")
+        Request(path: "/Sessions/\(sessionID)/User/\(userID)", method: "DELETE", id: "RemoveUserFromSession")
     }
 }

--- a/Sources/Paths/RemoveVirtualFolderAPI.swift
+++ b/Sources/Paths/RemoveVirtualFolderAPI.swift
@@ -14,8 +14,8 @@ extension Paths {
     /// Removes a virtual folder.
     public static func removeVirtualFolder(name: String? = nil, isRefreshLibrary: Bool? = nil) -> Request<Void> {
         Request(
+            path: "/Library/VirtualFolders",
             method: "DELETE",
-            url: "/Library/VirtualFolders",
             query: makeRemoveVirtualFolderQuery(name, isRefreshLibrary),
             id: "RemoveVirtualFolder"
         )

--- a/Sources/Paths/RenameVirtualFolderAPI.swift
+++ b/Sources/Paths/RenameVirtualFolderAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 public extension Paths {
     /// Renames a virtual folder.
     static func renameVirtualFolder(parameters: RenameVirtualFolderParameters? = nil) -> Request<Void> {
-        Request(method: "POST", url: "/Library/VirtualFolders/Name", query: parameters?.asQuery, id: "RenameVirtualFolder")
+        Request(path: "/Library/VirtualFolders/Name", method: "POST", query: parameters?.asQuery, id: "RenameVirtualFolder")
     }
 
     struct RenameVirtualFolderParameters {

--- a/Sources/Paths/ReportPlaybackProgressAPI.swift
+++ b/Sources/Paths/ReportPlaybackProgressAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Reports playback progress within a session.
     static func reportPlaybackProgress(_ body: JellyfinAPI.PlaybackProgressInfo? = nil) -> Request<Void> {
-        Request(method: "POST", url: "/Sessions/Playing/Progress", body: body, id: "ReportPlaybackProgress")
+        Request(path: "/Sessions/Playing/Progress", method: "POST", body: body, id: "ReportPlaybackProgress")
     }
 }

--- a/Sources/Paths/ReportPlaybackStartAPI.swift
+++ b/Sources/Paths/ReportPlaybackStartAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Reports playback has started within a session.
     static func reportPlaybackStart(_ body: JellyfinAPI.PlaybackStartInfo? = nil) -> Request<Void> {
-        Request(method: "POST", url: "/Sessions/Playing", body: body, id: "ReportPlaybackStart")
+        Request(path: "/Sessions/Playing", method: "POST", body: body, id: "ReportPlaybackStart")
     }
 }

--- a/Sources/Paths/ReportPlaybackStoppedAPI.swift
+++ b/Sources/Paths/ReportPlaybackStoppedAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Reports playback has stopped within a session.
     static func reportPlaybackStopped(_ body: JellyfinAPI.PlaybackStopInfo? = nil) -> Request<Void> {
-        Request(method: "POST", url: "/Sessions/Playing/Stopped", body: body, id: "ReportPlaybackStopped")
+        Request(path: "/Sessions/Playing/Stopped", method: "POST", body: body, id: "ReportPlaybackStopped")
     }
 }

--- a/Sources/Paths/ReportSessionEndedAPI.swift
+++ b/Sources/Paths/ReportSessionEndedAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Reports that a session has ended.
     static var reportSessionEnded: Request<Void> {
-        Request(method: "POST", url: "/Sessions/Logout", id: "ReportSessionEnded")
+        Request(path: "/Sessions/Logout", method: "POST", id: "ReportSessionEnded")
     }
 }

--- a/Sources/Paths/ReportViewingAPI.swift
+++ b/Sources/Paths/ReportViewingAPI.swift
@@ -13,7 +13,7 @@ import URLQueryEncoder
 extension Paths {
     /// Reports that a session is viewing an item.
     public static func reportViewing(sessionID: String? = nil, itemID: String) -> Request<Void> {
-        Request(method: "POST", url: "/Sessions/Viewing", query: makeReportViewingQuery(sessionID, itemID), id: "ReportViewing")
+        Request(path: "/Sessions/Viewing", method: "POST", query: makeReportViewingQuery(sessionID, itemID), id: "ReportViewing")
     }
 
     private static func makeReportViewingQuery(_ sessionID: String?, _ itemID: String) -> [(String, String?)] {

--- a/Sources/Paths/ResetTunerAPI.swift
+++ b/Sources/Paths/ResetTunerAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Resets a tv tuner.
     static func resetTuner(tunerID: String) -> Request<Void> {
-        Request(method: "POST", url: "/LiveTv/Tuners/\(tunerID)/Reset", id: "ResetTuner")
+        Request(path: "/LiveTv/Tuners/\(tunerID)/Reset", method: "POST", id: "ResetTuner")
     }
 }

--- a/Sources/Paths/RestartApplicationAPI.swift
+++ b/Sources/Paths/RestartApplicationAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Restarts the application.
     static var restartApplication: Request<Void> {
-        Request(method: "POST", url: "/System/Restart", id: "RestartApplication")
+        Request(path: "/System/Restart", method: "POST", id: "RestartApplication")
     }
 }

--- a/Sources/Paths/RevokeKeyAPI.swift
+++ b/Sources/Paths/RevokeKeyAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Remove an api key.
     static func revokeKey(key: String) -> Request<Void> {
-        Request(method: "DELETE", url: "/Auth/Keys/\(key)", id: "RevokeKey")
+        Request(path: "/Auth/Keys/\(key)", method: "DELETE", id: "RevokeKey")
     }
 }

--- a/Sources/Paths/SearchRemoteSubtitlesAPI.swift
+++ b/Sources/Paths/SearchRemoteSubtitlesAPI.swift
@@ -18,8 +18,8 @@ extension Paths {
         isPerfectMatch: Bool? = nil
     ) -> Request<[JellyfinAPI.RemoteSubtitleInfo]> {
         Request(
+            path: "/Items/\(itemID)/RemoteSearch/Subtitles/\(language)",
             method: "GET",
-            url: "/Items/\(itemID)/RemoteSearch/Subtitles/\(language)",
             query: makeSearchRemoteSubtitlesQuery(isPerfectMatch),
             id: "SearchRemoteSubtitles"
         )

--- a/Sources/Paths/SendFullGeneralCommandAPI.swift
+++ b/Sources/Paths/SendFullGeneralCommandAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Issues a full general command to a client.
     static func sendFullGeneralCommand(sessionID: String, _ body: JellyfinAPI.GeneralCommand) -> Request<Void> {
-        Request(method: "POST", url: "/Sessions/\(sessionID)/Command", body: body, id: "SendFullGeneralCommand")
+        Request(path: "/Sessions/\(sessionID)/Command", method: "POST", body: body, id: "SendFullGeneralCommand")
     }
 }

--- a/Sources/Paths/SendGeneralCommandAPI.swift
+++ b/Sources/Paths/SendGeneralCommandAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Issues a general command to a client.
     static func sendGeneralCommand(sessionID: String, command: String) -> Request<Void> {
-        Request(method: "POST", url: "/Sessions/\(sessionID)/Command/\(command)", id: "SendGeneralCommand")
+        Request(path: "/Sessions/\(sessionID)/Command/\(command)", method: "POST", id: "SendGeneralCommand")
     }
 }

--- a/Sources/Paths/SendMessageCommandAPI.swift
+++ b/Sources/Paths/SendMessageCommandAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Issues a command to a client to display a message to the user.
     static func sendMessageCommand(sessionID: String, _ body: JellyfinAPI.MessageCommand) -> Request<Void> {
-        Request(method: "POST", url: "/Sessions/\(sessionID)/Message", body: body, id: "SendMessageCommand")
+        Request(path: "/Sessions/\(sessionID)/Message", method: "POST", body: body, id: "SendMessageCommand")
     }
 }

--- a/Sources/Paths/SendPlaystateCommandAPI.swift
+++ b/Sources/Paths/SendPlaystateCommandAPI.swift
@@ -19,8 +19,8 @@ extension Paths {
         controllingUserID: String? = nil
     ) -> Request<Void> {
         Request(
+            path: "/Sessions/\(sessionID)/Playing/\(command)",
             method: "POST",
-            url: "/Sessions/\(sessionID)/Playing/\(command)",
             query: makeSendPlaystateCommandQuery(seekPositionTicks, controllingUserID),
             id: "SendPlaystateCommand"
         )

--- a/Sources/Paths/SendSystemCommandAPI.swift
+++ b/Sources/Paths/SendSystemCommandAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Issues a system command to a client.
     static func sendSystemCommand(sessionID: String, command: String) -> Request<Void> {
-        Request(method: "POST", url: "/Sessions/\(sessionID)/System/\(command)", id: "SendSystemCommand")
+        Request(path: "/Sessions/\(sessionID)/System/\(command)", method: "POST", id: "SendSystemCommand")
     }
 }

--- a/Sources/Paths/SetChannelMappingAPI.swift
+++ b/Sources/Paths/SetChannelMappingAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Set channel mappings.
     static func setChannelMapping(_ body: JellyfinAPI.SetChannelMappingDto) -> Request<JellyfinAPI.TunerChannelMapping> {
-        Request(method: "POST", url: "/LiveTv/ChannelMappings", body: body, id: "SetChannelMapping")
+        Request(path: "/LiveTv/ChannelMappings", method: "POST", body: body, id: "SetChannelMapping")
     }
 }

--- a/Sources/Paths/SetItemImageAPI.swift
+++ b/Sources/Paths/SetItemImageAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Set item image.
     static func setItemImage(itemID: String, imageType: String, _ body: Data? = nil) -> Request<Void> {
-        Request(method: "POST", url: "/Items/\(itemID)/Images/\(imageType)", body: body, id: "SetItemImage")
+        Request(path: "/Items/\(itemID)/Images/\(imageType)", method: "POST", body: body, id: "SetItemImage")
     }
 }

--- a/Sources/Paths/SetItemImageByIndexAPI.swift
+++ b/Sources/Paths/SetItemImageByIndexAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Set item image.
     static func setItemImageByIndex(itemID: String, imageType: String, imageIndex: Int, _ body: Data? = nil) -> Request<Void> {
-        Request(method: "POST", url: "/Items/\(itemID)/Images/\(imageType)/\(imageIndex)", body: body, id: "SetItemImageByIndex")
+        Request(path: "/Items/\(itemID)/Images/\(imageType)/\(imageIndex)", method: "POST", body: body, id: "SetItemImageByIndex")
     }
 }

--- a/Sources/Paths/SetReadAPI.swift
+++ b/Sources/Paths/SetReadAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Sets notifications as read.
     static func setRead(userID: String) -> Request<Void> {
-        Request(method: "POST", url: "/Notifications/\(userID)/Read", id: "SetRead")
+        Request(path: "/Notifications/\(userID)/Read", method: "POST", id: "SetRead")
     }
 }

--- a/Sources/Paths/SetRemoteAccessAPI.swift
+++ b/Sources/Paths/SetRemoteAccessAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Sets remote access and UPnP.
     static func setRemoteAccess(_ body: JellyfinAPI.StartupRemoteAccessDto) -> Request<Void> {
-        Request(method: "POST", url: "/Startup/RemoteAccess", body: body, id: "SetRemoteAccess")
+        Request(path: "/Startup/RemoteAccess", method: "POST", body: body, id: "SetRemoteAccess")
     }
 }

--- a/Sources/Paths/SetRepositoriesAPI.swift
+++ b/Sources/Paths/SetRepositoriesAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Sets the enabled and existing package repositories.
     static func setRepositories(_ body: [JellyfinAPI.RepositoryInfo]) -> Request<Void> {
-        Request(method: "POST", url: "/Repositories", body: body, id: "SetRepositories")
+        Request(path: "/Repositories", method: "POST", body: body, id: "SetRepositories")
     }
 }

--- a/Sources/Paths/SetUnreadAPI.swift
+++ b/Sources/Paths/SetUnreadAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Sets notifications as unread.
     static func setUnread(userID: String) -> Request<Void> {
-        Request(method: "POST", url: "/Notifications/\(userID)/Unread", id: "SetUnread")
+        Request(path: "/Notifications/\(userID)/Unread", method: "POST", id: "SetUnread")
     }
 }

--- a/Sources/Paths/ShutdownApplicationAPI.swift
+++ b/Sources/Paths/ShutdownApplicationAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Shuts down the application.
     static var shutdownApplication: Request<Void> {
-        Request(method: "POST", url: "/System/Shutdown", id: "ShutdownApplication")
+        Request(path: "/System/Shutdown", method: "POST", id: "ShutdownApplication")
     }
 }

--- a/Sources/Paths/StartTaskAPI.swift
+++ b/Sources/Paths/StartTaskAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Start specified task.
     static func startTask(taskID: String) -> Request<Void> {
-        Request(method: "POST", url: "/ScheduledTasks/Running/\(taskID)", id: "StartTask")
+        Request(path: "/ScheduledTasks/Running/\(taskID)", method: "POST", id: "StartTask")
     }
 }

--- a/Sources/Paths/StopEncodingProcessAPI.swift
+++ b/Sources/Paths/StopEncodingProcessAPI.swift
@@ -14,8 +14,8 @@ public extension Paths {
     /// Stops an active encoding.
     static func stopEncodingProcess(deviceID: String, playSessionID: String) -> Request<Void> {
         Request(
+            path: "/Videos/ActiveEncodings",
             method: "DELETE",
-            url: "/Videos/ActiveEncodings",
             query: [("deviceId", deviceID), ("playSessionId", playSessionID)],
             id: "StopEncodingProcess"
         )

--- a/Sources/Paths/StopTaskAPI.swift
+++ b/Sources/Paths/StopTaskAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Stop specified task.
     static func stopTask(taskID: String) -> Request<Void> {
-        Request(method: "DELETE", url: "/ScheduledTasks/Running/\(taskID)", id: "StopTask")
+        Request(path: "/ScheduledTasks/Running/\(taskID)", method: "DELETE", id: "StopTask")
     }
 }

--- a/Sources/Paths/SyncPlayBufferingAPI.swift
+++ b/Sources/Paths/SyncPlayBufferingAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Notify SyncPlay group that member is buffering.
     static func syncPlayBuffering(_ body: JellyfinAPI.BufferRequestDto) -> Request<Void> {
-        Request(method: "POST", url: "/SyncPlay/Buffering", body: body, id: "SyncPlayBuffering")
+        Request(path: "/SyncPlay/Buffering", method: "POST", body: body, id: "SyncPlayBuffering")
     }
 }

--- a/Sources/Paths/SyncPlayCreateGroupAPI.swift
+++ b/Sources/Paths/SyncPlayCreateGroupAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Create a new SyncPlay group.
     static func syncPlayCreateGroup(_ body: JellyfinAPI.NewGroupRequestDto) -> Request<Void> {
-        Request(method: "POST", url: "/SyncPlay/New", body: body, id: "SyncPlayCreateGroup")
+        Request(path: "/SyncPlay/New", method: "POST", body: body, id: "SyncPlayCreateGroup")
     }
 }

--- a/Sources/Paths/SyncPlayGetGroupsAPI.swift
+++ b/Sources/Paths/SyncPlayGetGroupsAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets all SyncPlay groups.
     static var syncPlayGetGroups: Request<[JellyfinAPI.GroupInfoDto]> {
-        Request(method: "GET", url: "/SyncPlay/List", id: "SyncPlayGetGroups")
+        Request(path: "/SyncPlay/List", method: "GET", id: "SyncPlayGetGroups")
     }
 }

--- a/Sources/Paths/SyncPlayJoinGroupAPI.swift
+++ b/Sources/Paths/SyncPlayJoinGroupAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Join an existing SyncPlay group.
     static func syncPlayJoinGroup(_ body: JellyfinAPI.JoinGroupRequestDto) -> Request<Void> {
-        Request(method: "POST", url: "/SyncPlay/Join", body: body, id: "SyncPlayJoinGroup")
+        Request(path: "/SyncPlay/Join", method: "POST", body: body, id: "SyncPlayJoinGroup")
     }
 }

--- a/Sources/Paths/SyncPlayLeaveGroupAPI.swift
+++ b/Sources/Paths/SyncPlayLeaveGroupAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Leave the joined SyncPlay group.
     static var syncPlayLeaveGroup: Request<Void> {
-        Request(method: "POST", url: "/SyncPlay/Leave", id: "SyncPlayLeaveGroup")
+        Request(path: "/SyncPlay/Leave", method: "POST", id: "SyncPlayLeaveGroup")
     }
 }

--- a/Sources/Paths/SyncPlayMovePlaylistItemAPI.swift
+++ b/Sources/Paths/SyncPlayMovePlaylistItemAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Request to move an item in the playlist in SyncPlay group.
     static func syncPlayMovePlaylistItem(_ body: JellyfinAPI.MovePlaylistItemRequestDto) -> Request<Void> {
-        Request(method: "POST", url: "/SyncPlay/MovePlaylistItem", body: body, id: "SyncPlayMovePlaylistItem")
+        Request(path: "/SyncPlay/MovePlaylistItem", method: "POST", body: body, id: "SyncPlayMovePlaylistItem")
     }
 }

--- a/Sources/Paths/SyncPlayNextItemAPI.swift
+++ b/Sources/Paths/SyncPlayNextItemAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Request next item in SyncPlay group.
     static func syncPlayNextItem(_ body: JellyfinAPI.NextItemRequestDto) -> Request<Void> {
-        Request(method: "POST", url: "/SyncPlay/NextItem", body: body, id: "SyncPlayNextItem")
+        Request(path: "/SyncPlay/NextItem", method: "POST", body: body, id: "SyncPlayNextItem")
     }
 }

--- a/Sources/Paths/SyncPlayPauseAPI.swift
+++ b/Sources/Paths/SyncPlayPauseAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Request pause in SyncPlay group.
     static var syncPlayPause: Request<Void> {
-        Request(method: "POST", url: "/SyncPlay/Pause", id: "SyncPlayPause")
+        Request(path: "/SyncPlay/Pause", method: "POST", id: "SyncPlayPause")
     }
 }

--- a/Sources/Paths/SyncPlayPingAPI.swift
+++ b/Sources/Paths/SyncPlayPingAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Update session ping.
     static func syncPlayPing(_ body: JellyfinAPI.PingRequestDto) -> Request<Void> {
-        Request(method: "POST", url: "/SyncPlay/Ping", body: body, id: "SyncPlayPing")
+        Request(path: "/SyncPlay/Ping", method: "POST", body: body, id: "SyncPlayPing")
     }
 }

--- a/Sources/Paths/SyncPlayPreviousItemAPI.swift
+++ b/Sources/Paths/SyncPlayPreviousItemAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Request previous item in SyncPlay group.
     static func syncPlayPreviousItem(_ body: JellyfinAPI.PreviousItemRequestDto) -> Request<Void> {
-        Request(method: "POST", url: "/SyncPlay/PreviousItem", body: body, id: "SyncPlayPreviousItem")
+        Request(path: "/SyncPlay/PreviousItem", method: "POST", body: body, id: "SyncPlayPreviousItem")
     }
 }

--- a/Sources/Paths/SyncPlayQueueAPI.swift
+++ b/Sources/Paths/SyncPlayQueueAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Request to queue items to the playlist of a SyncPlay group.
     static func syncPlayQueue(_ body: JellyfinAPI.QueueRequestDto) -> Request<Void> {
-        Request(method: "POST", url: "/SyncPlay/Queue", body: body, id: "SyncPlayQueue")
+        Request(path: "/SyncPlay/Queue", method: "POST", body: body, id: "SyncPlayQueue")
     }
 }

--- a/Sources/Paths/SyncPlayReadyAPI.swift
+++ b/Sources/Paths/SyncPlayReadyAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Notify SyncPlay group that member is ready for playback.
     static func syncPlayReady(_ body: JellyfinAPI.ReadyRequestDto) -> Request<Void> {
-        Request(method: "POST", url: "/SyncPlay/Ready", body: body, id: "SyncPlayReady")
+        Request(path: "/SyncPlay/Ready", method: "POST", body: body, id: "SyncPlayReady")
     }
 }

--- a/Sources/Paths/SyncPlayRemoveFromPlaylistAPI.swift
+++ b/Sources/Paths/SyncPlayRemoveFromPlaylistAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Request to remove items from the playlist in SyncPlay group.
     static func syncPlayRemoveFromPlaylist(_ body: JellyfinAPI.RemoveFromPlaylistRequestDto) -> Request<Void> {
-        Request(method: "POST", url: "/SyncPlay/RemoveFromPlaylist", body: body, id: "SyncPlayRemoveFromPlaylist")
+        Request(path: "/SyncPlay/RemoveFromPlaylist", method: "POST", body: body, id: "SyncPlayRemoveFromPlaylist")
     }
 }

--- a/Sources/Paths/SyncPlaySeekAPI.swift
+++ b/Sources/Paths/SyncPlaySeekAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Request seek in SyncPlay group.
     static func syncPlaySeek(_ body: JellyfinAPI.SeekRequestDto) -> Request<Void> {
-        Request(method: "POST", url: "/SyncPlay/Seek", body: body, id: "SyncPlaySeek")
+        Request(path: "/SyncPlay/Seek", method: "POST", body: body, id: "SyncPlaySeek")
     }
 }

--- a/Sources/Paths/SyncPlaySetIgnoreWaitAPI.swift
+++ b/Sources/Paths/SyncPlaySetIgnoreWaitAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Request SyncPlay group to ignore member during group-wait.
     static func syncPlaySetIgnoreWait(_ body: JellyfinAPI.IgnoreWaitRequestDto) -> Request<Void> {
-        Request(method: "POST", url: "/SyncPlay/SetIgnoreWait", body: body, id: "SyncPlaySetIgnoreWait")
+        Request(path: "/SyncPlay/SetIgnoreWait", method: "POST", body: body, id: "SyncPlaySetIgnoreWait")
     }
 }

--- a/Sources/Paths/SyncPlaySetNewQueueAPI.swift
+++ b/Sources/Paths/SyncPlaySetNewQueueAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Request to set new playlist in SyncPlay group.
     static func syncPlaySetNewQueue(_ body: JellyfinAPI.PlayRequestDto) -> Request<Void> {
-        Request(method: "POST", url: "/SyncPlay/SetNewQueue", body: body, id: "SyncPlaySetNewQueue")
+        Request(path: "/SyncPlay/SetNewQueue", method: "POST", body: body, id: "SyncPlaySetNewQueue")
     }
 }

--- a/Sources/Paths/SyncPlaySetPlaylistItemAPI.swift
+++ b/Sources/Paths/SyncPlaySetPlaylistItemAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Request to change playlist item in SyncPlay group.
     static func syncPlaySetPlaylistItem(_ body: JellyfinAPI.SetPlaylistItemRequestDto) -> Request<Void> {
-        Request(method: "POST", url: "/SyncPlay/SetPlaylistItem", body: body, id: "SyncPlaySetPlaylistItem")
+        Request(path: "/SyncPlay/SetPlaylistItem", method: "POST", body: body, id: "SyncPlaySetPlaylistItem")
     }
 }

--- a/Sources/Paths/SyncPlaySetRepeatModeAPI.swift
+++ b/Sources/Paths/SyncPlaySetRepeatModeAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Request to set repeat mode in SyncPlay group.
     static func syncPlaySetRepeatMode(_ body: JellyfinAPI.SetRepeatModeRequestDto) -> Request<Void> {
-        Request(method: "POST", url: "/SyncPlay/SetRepeatMode", body: body, id: "SyncPlaySetRepeatMode")
+        Request(path: "/SyncPlay/SetRepeatMode", method: "POST", body: body, id: "SyncPlaySetRepeatMode")
     }
 }

--- a/Sources/Paths/SyncPlaySetShuffleModeAPI.swift
+++ b/Sources/Paths/SyncPlaySetShuffleModeAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Request to set shuffle mode in SyncPlay group.
     static func syncPlaySetShuffleMode(_ body: JellyfinAPI.SetShuffleModeRequestDto) -> Request<Void> {
-        Request(method: "POST", url: "/SyncPlay/SetShuffleMode", body: body, id: "SyncPlaySetShuffleMode")
+        Request(path: "/SyncPlay/SetShuffleMode", method: "POST", body: body, id: "SyncPlaySetShuffleMode")
     }
 }

--- a/Sources/Paths/SyncPlayStopAPI.swift
+++ b/Sources/Paths/SyncPlayStopAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Request stop in SyncPlay group.
     static var syncPlayStop: Request<Void> {
-        Request(method: "POST", url: "/SyncPlay/Stop", id: "SyncPlayStop")
+        Request(path: "/SyncPlay/Stop", method: "POST", id: "SyncPlayStop")
     }
 }

--- a/Sources/Paths/SyncPlayUnpauseAPI.swift
+++ b/Sources/Paths/SyncPlayUnpauseAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Request unpause in SyncPlay group.
     static var syncPlayUnpause: Request<Void> {
-        Request(method: "POST", url: "/SyncPlay/Unpause", id: "SyncPlayUnpause")
+        Request(path: "/SyncPlay/Unpause", method: "POST", id: "SyncPlayUnpause")
     }
 }

--- a/Sources/Paths/TmdbClientConfigurationAPI.swift
+++ b/Sources/Paths/TmdbClientConfigurationAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Gets the TMDb image configuration options.
     static var tmdbClientConfiguration: Request<JellyfinAPI.ConfigImageTypes> {
-        Request(method: "GET", url: "/Tmdb/ClientConfiguration", id: "TmdbClientConfiguration")
+        Request(path: "/Tmdb/ClientConfiguration", method: "GET", id: "TmdbClientConfiguration")
     }
 }

--- a/Sources/Paths/UninstallPluginAPI.swift
+++ b/Sources/Paths/UninstallPluginAPI.swift
@@ -14,6 +14,6 @@ public extension Paths {
     /// Uninstalls a plugin.
     @available(*, deprecated, message: "Deprecated")
     static func uninstallPlugin(pluginID: String) -> Request<Void> {
-        Request(method: "DELETE", url: "/Plugins/\(pluginID)", id: "UninstallPlugin")
+        Request(path: "/Plugins/\(pluginID)", method: "DELETE", id: "UninstallPlugin")
     }
 }

--- a/Sources/Paths/UninstallPluginByVersionAPI.swift
+++ b/Sources/Paths/UninstallPluginByVersionAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Uninstalls a plugin by version.
     static func uninstallPluginByVersion(pluginID: String, version: String) -> Request<Void> {
-        Request(method: "DELETE", url: "/Plugins/\(pluginID)/\(version)", id: "UninstallPluginByVersion")
+        Request(path: "/Plugins/\(pluginID)/\(version)", method: "DELETE", id: "UninstallPluginByVersion")
     }
 }

--- a/Sources/Paths/UnmarkFavoriteItemAPI.swift
+++ b/Sources/Paths/UnmarkFavoriteItemAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Unmarks item as a favorite.
     static func unmarkFavoriteItem(userID: String, itemID: String) -> Request<JellyfinAPI.UserItemDataDto> {
-        Request(method: "DELETE", url: "/Users/\(userID)/FavoriteItems/\(itemID)", id: "UnmarkFavoriteItem")
+        Request(path: "/Users/\(userID)/FavoriteItems/\(itemID)", method: "DELETE", id: "UnmarkFavoriteItem")
     }
 }

--- a/Sources/Paths/UpdateConfigurationAPI.swift
+++ b/Sources/Paths/UpdateConfigurationAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Updates application configuration.
     static func updateConfiguration(_ body: JellyfinAPI.ServerConfiguration) -> Request<Void> {
-        Request(method: "POST", url: "/System/Configuration", body: body, id: "UpdateConfiguration")
+        Request(path: "/System/Configuration", method: "POST", body: body, id: "UpdateConfiguration")
     }
 }

--- a/Sources/Paths/UpdateDeviceOptionsAPI.swift
+++ b/Sources/Paths/UpdateDeviceOptionsAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Update device options.
     static func updateDeviceOptions(id: String, _ body: JellyfinAPI.DeviceOptionsDto) -> Request<Void> {
-        Request(method: "POST", url: "/Devices/Options", query: [("id", id)], body: body, id: "UpdateDeviceOptions")
+        Request(path: "/Devices/Options", method: "POST", query: [("id", id)], body: body, id: "UpdateDeviceOptions")
     }
 }

--- a/Sources/Paths/UpdateDisplayPreferencesAPI.swift
+++ b/Sources/Paths/UpdateDisplayPreferencesAPI.swift
@@ -19,8 +19,8 @@ public extension Paths {
         _ body: JellyfinAPI.DisplayPreferencesDto
     ) -> Request<Void> {
         Request(
+            path: "/DisplayPreferences/\(displayPreferencesID)",
             method: "POST",
-            url: "/DisplayPreferences/\(displayPreferencesID)",
             query: [("userId", userID), ("client", client)],
             body: body,
             id: "UpdateDisplayPreferences"

--- a/Sources/Paths/UpdateInitialConfigurationAPI.swift
+++ b/Sources/Paths/UpdateInitialConfigurationAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Sets the initial startup wizard configuration.
     static func updateInitialConfiguration(_ body: JellyfinAPI.StartupConfigurationDto) -> Request<Void> {
-        Request(method: "POST", url: "/Startup/Configuration", body: body, id: "UpdateInitialConfiguration")
+        Request(path: "/Startup/Configuration", method: "POST", body: body, id: "UpdateInitialConfiguration")
     }
 }

--- a/Sources/Paths/UpdateItemAPI.swift
+++ b/Sources/Paths/UpdateItemAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Updates an item.
     static func updateItem(itemID: String, _ body: JellyfinAPI.BaseItemDto) -> Request<Void> {
-        Request(method: "POST", url: "/Items/\(itemID)", body: body, id: "UpdateItem")
+        Request(path: "/Items/\(itemID)", method: "POST", body: body, id: "UpdateItem")
     }
 }

--- a/Sources/Paths/UpdateItemContentTypeAPI.swift
+++ b/Sources/Paths/UpdateItemContentTypeAPI.swift
@@ -14,8 +14,8 @@ extension Paths {
     /// Updates an item's content type.
     public static func updateItemContentType(itemID: String, contentType: String? = nil) -> Request<Void> {
         Request(
+            path: "/Items/\(itemID)/ContentType",
             method: "POST",
-            url: "/Items/\(itemID)/ContentType",
             query: makeUpdateItemContentTypeQuery(contentType),
             id: "UpdateItemContentType"
         )

--- a/Sources/Paths/UpdateItemImageIndexAPI.swift
+++ b/Sources/Paths/UpdateItemImageIndexAPI.swift
@@ -14,8 +14,8 @@ public extension Paths {
     /// Updates the index for an item image.
     static func updateItemImageIndex(itemID: String, imageType: String, imageIndex: Int, newIndex: Int) -> Request<Void> {
         Request(
+            path: "/Items/\(itemID)/Images/\(imageType)/\(imageIndex)/Index",
             method: "POST",
-            url: "/Items/\(itemID)/Images/\(imageType)/\(imageIndex)/Index",
             query: [("newIndex", String(newIndex))],
             id: "UpdateItemImageIndex"
         )

--- a/Sources/Paths/UpdateLibraryOptionsAPI.swift
+++ b/Sources/Paths/UpdateLibraryOptionsAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Update library options.
     static func updateLibraryOptions(_ body: JellyfinAPI.UpdateLibraryOptionsDto? = nil) -> Request<Void> {
-        Request(method: "POST", url: "/Library/VirtualFolders/LibraryOptions", body: body, id: "UpdateLibraryOptions")
+        Request(path: "/Library/VirtualFolders/LibraryOptions", method: "POST", body: body, id: "UpdateLibraryOptions")
     }
 }

--- a/Sources/Paths/UpdateMediaEncoderPathAPI.swift
+++ b/Sources/Paths/UpdateMediaEncoderPathAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Updates the path to the media encoder.
     static func updateMediaEncoderPath(_ body: JellyfinAPI.MediaEncoderPathDto) -> Request<Void> {
-        Request(method: "POST", url: "/System/MediaEncoder/Path", body: body, id: "UpdateMediaEncoderPath")
+        Request(path: "/System/MediaEncoder/Path", method: "POST", body: body, id: "UpdateMediaEncoderPath")
     }
 }

--- a/Sources/Paths/UpdateMediaPathAPI.swift
+++ b/Sources/Paths/UpdateMediaPathAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Updates a media path.
     static func updateMediaPath(_ body: JellyfinAPI.UpdateMediaPathRequestDto) -> Request<Void> {
-        Request(method: "POST", url: "/Library/VirtualFolders/Paths/Update", body: body, id: "UpdateMediaPath")
+        Request(path: "/Library/VirtualFolders/Paths/Update", method: "POST", body: body, id: "UpdateMediaPath")
     }
 }

--- a/Sources/Paths/UpdateNamedConfigurationAPI.swift
+++ b/Sources/Paths/UpdateNamedConfigurationAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Updates named configuration.
     static func updateNamedConfiguration(key: String, _ body: AnyJSON) -> Request<Void> {
-        Request(method: "POST", url: "/System/Configuration/\(key)", body: body, id: "UpdateNamedConfiguration")
+        Request(path: "/System/Configuration/\(key)", method: "POST", body: body, id: "UpdateNamedConfiguration")
     }
 }

--- a/Sources/Paths/UpdatePluginConfigurationAPI.swift
+++ b/Sources/Paths/UpdatePluginConfigurationAPI.swift
@@ -15,6 +15,6 @@ public extension Paths {
     ///
     /// Accepts plugin configuration as JSON body.
     static func updatePluginConfiguration(pluginID: String) -> Request<Void> {
-        Request(method: "POST", url: "/Plugins/\(pluginID)/Configuration", id: "UpdatePluginConfiguration")
+        Request(path: "/Plugins/\(pluginID)/Configuration", method: "POST", id: "UpdatePluginConfiguration")
     }
 }

--- a/Sources/Paths/UpdateProfileAPI.swift
+++ b/Sources/Paths/UpdateProfileAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Updates a profile.
     static func updateProfile(profileID: String, _ body: JellyfinAPI.DeviceProfile? = nil) -> Request<Void> {
-        Request(method: "POST", url: "/Dlna/Profiles/\(profileID)", body: body, id: "UpdateProfile")
+        Request(path: "/Dlna/Profiles/\(profileID)", method: "POST", body: body, id: "UpdateProfile")
     }
 }

--- a/Sources/Paths/UpdateSeriesTimerAPI.swift
+++ b/Sources/Paths/UpdateSeriesTimerAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Updates a live tv series timer.
     static func updateSeriesTimer(timerID: String, _ body: JellyfinAPI.SeriesTimerInfoDto? = nil) -> Request<Void> {
-        Request(method: "POST", url: "/LiveTv/SeriesTimers/\(timerID)", body: body, id: "UpdateSeriesTimer")
+        Request(path: "/LiveTv/SeriesTimers/\(timerID)", method: "POST", body: body, id: "UpdateSeriesTimer")
     }
 }

--- a/Sources/Paths/UpdateStartupUserAPI.swift
+++ b/Sources/Paths/UpdateStartupUserAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Sets the user name and password.
     static func updateStartupUser(_ body: JellyfinAPI.StartupUserDto? = nil) -> Request<Void> {
-        Request(method: "POST", url: "/Startup/User", body: body, id: "UpdateStartupUser")
+        Request(path: "/Startup/User", method: "POST", body: body, id: "UpdateStartupUser")
     }
 }

--- a/Sources/Paths/UpdateTaskAPI.swift
+++ b/Sources/Paths/UpdateTaskAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Update specified task triggers.
     static func updateTask(taskID: String, _ body: [JellyfinAPI.TaskTriggerInfo]) -> Request<Void> {
-        Request(method: "POST", url: "/ScheduledTasks/\(taskID)/Triggers", body: body, id: "UpdateTask")
+        Request(path: "/ScheduledTasks/\(taskID)/Triggers", method: "POST", body: body, id: "UpdateTask")
     }
 }

--- a/Sources/Paths/UpdateTimerAPI.swift
+++ b/Sources/Paths/UpdateTimerAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Updates a live tv timer.
     static func updateTimer(timerID: String, _ body: JellyfinAPI.TimerInfoDto? = nil) -> Request<Void> {
-        Request(method: "POST", url: "/LiveTv/Timers/\(timerID)", body: body, id: "UpdateTimer")
+        Request(path: "/LiveTv/Timers/\(timerID)", method: "POST", body: body, id: "UpdateTimer")
     }
 }

--- a/Sources/Paths/UpdateUserAPI.swift
+++ b/Sources/Paths/UpdateUserAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Updates a user.
     static func updateUser(userID: String, _ body: JellyfinAPI.UserDto) -> Request<Void> {
-        Request(method: "POST", url: "/Users/\(userID)", body: body, id: "UpdateUser")
+        Request(path: "/Users/\(userID)", method: "POST", body: body, id: "UpdateUser")
     }
 }

--- a/Sources/Paths/UpdateUserConfigurationAPI.swift
+++ b/Sources/Paths/UpdateUserConfigurationAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Updates a user configuration.
     static func updateUserConfiguration(userID: String, _ body: JellyfinAPI.UserConfiguration) -> Request<Void> {
-        Request(method: "POST", url: "/Users/\(userID)/Configuration", body: body, id: "UpdateUserConfiguration")
+        Request(path: "/Users/\(userID)/Configuration", method: "POST", body: body, id: "UpdateUserConfiguration")
     }
 }

--- a/Sources/Paths/UpdateUserEasyPasswordAPI.swift
+++ b/Sources/Paths/UpdateUserEasyPasswordAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Updates a user's easy password.
     static func updateUserEasyPassword(userID: String, _ body: JellyfinAPI.UpdateUserEasyPassword) -> Request<Void> {
-        Request(method: "POST", url: "/Users/\(userID)/EasyPassword", body: body, id: "UpdateUserEasyPassword")
+        Request(path: "/Users/\(userID)/EasyPassword", method: "POST", body: body, id: "UpdateUserEasyPassword")
     }
 }

--- a/Sources/Paths/UpdateUserItemRatingAPI.swift
+++ b/Sources/Paths/UpdateUserItemRatingAPI.swift
@@ -14,8 +14,8 @@ extension Paths {
     /// Updates a user's rating for an item.
     public static func updateUserItemRating(userID: String, itemID: String, isLikes: Bool? = nil) -> Request<JellyfinAPI.UserItemDataDto> {
         Request(
+            path: "/Users/\(userID)/Items/\(itemID)/Rating",
             method: "POST",
-            url: "/Users/\(userID)/Items/\(itemID)/Rating",
             query: makeUpdateUserItemRatingQuery(isLikes),
             id: "UpdateUserItemRating"
         )

--- a/Sources/Paths/UpdateUserPasswordAPI.swift
+++ b/Sources/Paths/UpdateUserPasswordAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Updates a user's password.
     static func updateUserPassword(userID: String, _ body: JellyfinAPI.UpdateUserPassword) -> Request<Void> {
-        Request(method: "POST", url: "/Users/\(userID)/Password", body: body, id: "UpdateUserPassword")
+        Request(path: "/Users/\(userID)/Password", method: "POST", body: body, id: "UpdateUserPassword")
     }
 }

--- a/Sources/Paths/UpdateUserPolicyAPI.swift
+++ b/Sources/Paths/UpdateUserPolicyAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Updates a user policy.
     static func updateUserPolicy(userID: String, _ body: JellyfinAPI.UserPolicy) -> Request<Void> {
-        Request(method: "POST", url: "/Users/\(userID)/Policy", body: body, id: "UpdateUserPolicy")
+        Request(path: "/Users/\(userID)/Policy", method: "POST", body: body, id: "UpdateUserPolicy")
     }
 }

--- a/Sources/Paths/UploadCustomSplashscreenAPI.swift
+++ b/Sources/Paths/UploadCustomSplashscreenAPI.swift
@@ -15,6 +15,6 @@ public extension Paths {
     ///
     /// The body is expected to the image contents base64 encoded.
     static func uploadCustomSplashscreen(_ body: Data? = nil) -> Request<Void> {
-        Request(method: "POST", url: "/Branding/Splashscreen", body: body, id: "UploadCustomSplashscreen")
+        Request(path: "/Branding/Splashscreen", method: "POST", body: body, id: "UploadCustomSplashscreen")
     }
 }

--- a/Sources/Paths/UploadSubtitleAPI.swift
+++ b/Sources/Paths/UploadSubtitleAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Upload an external subtitle file.
     static func uploadSubtitle(itemID: String, _ body: JellyfinAPI.UploadSubtitleDto) -> Request<Void> {
-        Request(method: "POST", url: "/Videos/\(itemID)/Subtitles", body: body, id: "UploadSubtitle")
+        Request(path: "/Videos/\(itemID)/Subtitles", method: "POST", body: body, id: "UploadSubtitle")
     }
 }

--- a/Sources/Paths/ValidatePathAPI.swift
+++ b/Sources/Paths/ValidatePathAPI.swift
@@ -13,6 +13,6 @@ import URLQueryEncoder
 public extension Paths {
     /// Validates path.
     static func validatePath(_ body: JellyfinAPI.ValidatePathDto) -> Request<Void> {
-        Request(method: "POST", url: "/Environment/ValidatePath", body: body, id: "ValidatePath")
+        Request(path: "/Environment/ValidatePath", method: "POST", body: body, id: "ValidatePath")
     }
 }

--- a/Sources/jellyfin-openapi-stable.json
+++ b/Sources/jellyfin-openapi-stable.json
@@ -2,8 +2,8 @@
   "openapi": "3.0.1",
   "info": {
     "title": "Jellyfin API",
-    "version": "10.8.9",
-    "x-jellyfin-version": "10.8.9"
+    "version": "10.8.10",
+    "x-jellyfin-version": "10.8.10"
   },
   "servers": [
     {
@@ -45013,7 +45013,7 @@
                 "$ref": "#/components/schemas/BaseItemKind"
               }
             ],
-            "description": "Gets or sets the type."
+            "description": "The base item kind."
           },
           "People": {
             "type": "array",
@@ -47230,7 +47230,7 @@
                 "$ref": "#/components/schemas/ScrollDirection"
               }
             ],
-            "description": "Gets or sets the scroll direction."
+            "description": "An enum representing the axis that should be scrolled."
           },
           "ShowBackdrop": {
             "type": "boolean",
@@ -47246,7 +47246,7 @@
                 "$ref": "#/components/schemas/SortOrder"
               }
             ],
-            "description": "Gets or sets the sort order."
+            "description": "An enum representing the sorting order."
           },
           "ShowSidebar": {
             "type": "boolean",
@@ -47419,15 +47419,15 @@
             "type": "string",
             "nullable": true
           },
+          "TonemappingMode": {
+            "type": "string",
+            "nullable": true
+          },
           "TonemappingRange": {
             "type": "string",
             "nullable": true
           },
           "TonemappingDesat": {
-            "type": "number",
-            "format": "double"
-          },
-          "TonemappingThreshold": {
             "type": "number",
             "format": "double"
           },
@@ -53218,7 +53218,7 @@
                 "$ref": "#/components/schemas/BaseItemDto"
               }
             ],
-            "description": "This is strictly used as a data transfer object from the api layer.\r\nThis holds information about a BaseItem in a format that is convenient for the client.",
+            "description": "Gets or sets the now playing item.",
             "nullable": true
           },
           "FullNowPlayingItem": {
@@ -55170,7 +55170,7 @@
                 "$ref": "#/components/schemas/SyncPlayUserAccessType"
               }
             ],
-            "description": "Gets or sets a value indicating what SyncPlay features the user can access."
+            "description": "Enum SyncPlayUserAccessType."
           }
         },
         "additionalProperties": false


### PR DESCRIPTION
I erroneously did #21 without taking into consideration the package changed a lot in v2.0 and how CreateAPI has also updated itself to generate for it.

Main changes:
- update to new `Request` initializer
- update `JellyfinClient`'s `APIClientDelegate` conformance for `func client<T>(_ client: APIClient, makeURLForRequest request: Request<T>)`
- update schema to 10.8.10, which only has a single entity field change and comment changes