### PR TITLE
Unstable Ignore Build

### DIFF
--- a/.github/workflows/sdk-unstable-branch.yaml
+++ b/.github/workflows/sdk-unstable-branch.yaml
@@ -21,16 +21,11 @@ jobs:
       with:
         ref: main
         token: ${{ secrets.JF_BOT_TOKEN }}
-    
-    - name: Download unstable OpenAPI schema
-      run: |
-        curl -sL https://repo.jellyfin.org/releases/openapi/jellyfin-openapi-unstable.json -o jellyfin-openapi-stable.json
-        cp -rf jellyfin-openapi-stable.json $GITHUB_WORKSPACE/Sources
 
     - name: Generate API
       run: |
         cd $GITHUB_WORKSPACE
-        swift package --allow-writing-to-package-directory generate-api
+        make update
 
     - name: Commit changes
       run: |

--- a/.github/workflows/sdk-unstable-branch.yaml
+++ b/.github/workflows/sdk-unstable-branch.yaml
@@ -32,10 +32,6 @@ jobs:
         cd $GITHUB_WORKSPACE
         swift package --allow-writing-to-package-directory generate-api
 
-    - name: Build
-      run: |
-        swift build
-
     - name: Commit changes
       run: |
         git config user.name jellyfin-bot


### PR DESCRIPTION
There is a weird generation issue that came up with the unstable spec and CreateAPI. Ignore the build so that it can "generate" even if incorrect so that corrections can be made.