### PR TITLE
Make 64 bit int a 64 bit int in Swift

### DIFF
--- a/Sources/create-api-config.yaml
+++ b/Sources/create-api-config.yaml
@@ -14,7 +14,7 @@ fileHeaderComment: |
 dataTypes:
   integer:
     int32: Int
-    int64: Int
+    int64: Int64
   string:
     uuid: String
     SpecialFeatureType: SpecialFeatureType


### PR DESCRIPTION
Hi! I'm working on a Jellyfin client, one of the platforms I'm supporting is the Apple Watch. The Apple Watch is only 64 bit when specified and as a result when integers are above the 32 bit limit there's an error. This PR fixes that issue. However, it requires slight change of code for clients as it's changing the data type. Thank you so much, have a good night!