### PR TITLE
QuickConnect, url, Tools

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "11b0f6a1c6b7ae3ecd73b80dcf4bdda16dc07751ff3cb9daa49662bfa7d72abc",
   "pins" : [
     {
       "identity" : "get",
@@ -19,5 +20,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -6,11 +6,11 @@ import PackageDescription
 let package = Package(
     name: "JellyfinAPI",
     platforms: [
-        .iOS(.v13),
-        .macCatalyst(.v13),
-        .macOS(.v10_15),
-        .watchOS(.v6),
-        .tvOS(.v13),
+        .iOS(.v16),
+        .macCatalyst(.v16),
+        .macOS(.v13),
+        .watchOS(.v9),
+        .tvOS(.v16),
     ],
     products: [
         .library(name: "JellyfinAPI", targets: ["JellyfinAPI"]),

--- a/README.md
+++ b/README.md
@@ -28,28 +28,17 @@ Alternatively, you can use your own network stack with the generated **Entities*
 
 ## Quick Connect
 
-The `QuickConnect` object has been provided to perform the Quick Connect authorization flow.
+`JellyfinClient` provides a Quick Connect authorization flow.
 
 ```swift
-/// Create a QuickConnect object with a JellyfinClient
-let quickConnect = QuickConnect(client: client)
-
-let quickConnectState = Task {
-	/// Listen to QuickConnect states with async/await or Combine
-	for await state in quickConnect.$state.values {
-		switch state {
-		/// Other cases ommitted
-		case let .polling(code: code):
-			print(code)
-		case let .authenticated(secret: secret):
-			/// Sign in with the Quick Connect secret
-			client.signIn(quickConnectSecret: secret)
-		}
-	}
+for try await state in client.quickConnect.connect() {
+    switch state {
+    case let .polling(code: code):
+        print("Code: \(code)")
+    case let .authenticated(secret: secret):
+        try await client.signIn(quickConnectSecret: secret)
+    }
 }
-
-/// Start the Quick Connect authorization flow
-quickConnect.start()
 ```
 
 ## Generation

--- a/Sources/JellyfinClient.swift
+++ b/Sources/JellyfinClient.swift
@@ -25,28 +25,6 @@ public final class JellyfinClient: @unchecked Sendable {
     private let sessionConfiguration: URLSessionConfiguration
     private var passthroughDelegate: PassthroughAPIClientDelegate
 
-    /// Create a `JellyfinClient` instance given a configuration and optional access token.
-    ///
-    /// - Note: A strong reference is made to the `delegate` if one is provided. Make sure to avoid
-    /// retain cycles if you are referencing the `JellyfinClient` instance from the delegate.
-    @available(*, deprecated, message: "Use the updated initializer to pass the access token in the configuration directly")
-    public convenience init(
-        configuration: Configuration,
-        sessionConfiguration: URLSessionConfiguration = .default,
-        sessionDelegate: URLSessionDelegate? = nil,
-        delegate: APIClientDelegate? = nil,
-        accessToken: String? = nil
-    ) {
-        let newConfiguration = configuration.with(accessToken: accessToken)
-
-        self.init(
-            configuration: newConfiguration,
-            delegate: delegate,
-            sessionConfiguration: sessionConfiguration,
-            sessionDelegate: sessionDelegate
-        )
-    }
-
     /// Create a `JellyfinClient` instance given a configuration.
     ///
     /// - Note: A strong reference is made to the `delegate` if one is provided. Make sure to avoid
@@ -80,9 +58,11 @@ public final class JellyfinClient: @unchecked Sendable {
             configuration.encoder = encoder
         }
 
-        self.passthroughDelegate.jellyfinClient = self
         self.passthroughDelegate.actualDelegate = delegate
+        self.passthroughDelegate.jellyfinClient = self
     }
+
+    // MARK: - Configuration
 
     public struct Configuration: Sendable {
 
@@ -189,6 +169,15 @@ public final class JellyfinClient: @unchecked Sendable {
 
 public extension JellyfinClient {
 
+    enum ClientError: Error {
+        case noAccessTokenInResponse
+    }
+
+    /// Quick Connect authorization helper.
+    var quickConnect: QuickConnect {
+        .init(client: self)
+    }
+
     /// Signs in a user given a username and password. On a successful response `accessToken` is set to the given access token.
     ///
     /// - Note: Overrides the current access token if one was previously set. Save this token locally or revoke it with `signOut` for proper
@@ -246,20 +235,25 @@ public extension JellyfinClient {
 
         self.configuration.accessToken = nil
     }
-}
 
-// MARK: ClientError
+    /// Creates a URL against the current server with the given `Request`.
+    func url(with request: Request<some Any>, queryAPIKey: Bool = false) -> URL? {
 
-extension JellyfinClient {
+        guard let path = request.url?.path else { return configuration.url }
+        let fullURL = url(path: path)
+        guard var components = URLComponents(url: fullURL, resolvingAgainstBaseURL: false) else { return nil }
 
-    enum ClientError: Error {
-        case noAccessTokenInResponse
+        components.queryItems = request.query?.map { URLQueryItem(name: $0.0, value: $0.1) } ?? []
 
-        var localizedDescription: String {
-            switch self {
-            case .noAccessTokenInResponse:
-                "No access token in authenticated response"
-            }
+        if queryAPIKey, let accessToken {
+            components.queryItems?.append(.init(name: "api_key", value: accessToken))
         }
+
+        return components.url ?? fullURL
+    }
+
+    /// Creates a URL against the current server with the given path.
+    func url(path: String) -> URL {
+        configuration.url.appending(component: path.trimmingPrefix(while: { $0 == "/" }))
     }
 }

--- a/Sources/QuickConnect.swift
+++ b/Sources/QuickConnect.swift
@@ -49,11 +49,9 @@ public struct QuickConnect: Sendable {
     /// - Parameters:
     ///   - poll: Poll interval in seconds
     ///   - max: Maximum number of polls
-    ///   - signIn: Automatically sign in with the retrieved secret when authenticated using `JellyfinClient.signIn(quickConnectSecret:)`
     public func connect(
         poll: Int = 5,
-        max: Int = 200,
-        signIn: Bool = false
+        max: Int = 200
     ) -> AsyncThrowingStream<Event, Error> {
 
         precondition(poll > 0, "Polling interval must be at least one second")
@@ -62,7 +60,7 @@ public struct QuickConnect: Sendable {
         return AsyncThrowingStream { continuation in
             let task = Task {
                 do {
-                    try await run(poll: poll, max: max, signIn: signIn) { state in
+                    try await run(poll: poll, max: max) { state in
                         continuation.yield(state)
                     }
                     continuation.finish()
@@ -82,7 +80,6 @@ public struct QuickConnect: Sendable {
     private func run(
         poll: Int,
         max: Int,
-        signIn: Bool,
         yield: (Event) -> Void
     ) async throws {
 
@@ -93,10 +90,6 @@ public struct QuickConnect: Sendable {
         let authorizedSecret = try await pollForAuthorization(secret: secret, interval: poll, max: max)
 
         yield(.authenticated(secret: authorizedSecret))
-
-        if signIn {
-            try await client.signIn(quickConnectSecret: authorizedSecret)
-        }
     }
 
     private func retrieveSecretAndCode() async throws -> (secret: String, code: String) {

--- a/Sources/QuickConnect.swift
+++ b/Sources/QuickConnect.swift
@@ -8,150 +8,101 @@
 
 import Foundation
 
-/// A provider for the Quick Connect authorization flow.
+/// Start `QuickConnect` from a `JellyfinClient` instance.
 ///
-/// To start the authorization flow, call `start()`. The `state` variable
-/// will be updated to the current flow state and can be subscribed to with
-/// async/await or Combine. See `QuickConnect.State` for all possible states.
-///
-/// To stop the authorization flow, typically for user cancellation, call `stop()`.
-public final class QuickConnect: ObservableObject, @unchecked Sendable {
+/// ## Example
+/// ```swift
+/// for try await event in client.quickConnect.connect() {
+///     switch event {
+///     case let .polling(code: code):
+///         print("Code: \(code)")
+///     case let .authenticated(secret: secret):
+///         try await client.signIn(quickConnectSecret: secret)
+///     }
+/// }
+/// ```
+public struct QuickConnect: Sendable {
 
-    // MARK: State
-
-    public enum State: Equatable {
-
-        /// Idle
-        case idle
-
-        /// Retrieving Quick Connect code
-        case retrievingCode
+    public enum Event: Equatable, Sendable {
 
         /// Polling with code
         case polling(code: String)
 
         /// Authenticated with secret
         case authenticated(secret: String)
-
-        /// An internal error has occurred
-        case error(QuickConnectError)
     }
 
-    // MARK: Error
+    enum QuickConnectError: Error {
 
-    public enum QuickConnectError: LocalizedError, Equatable {
-
-        /// Polling has hit its maximum
         case maxPollingHit
-
-        /// An other error has occurred, typically a network error
-        case other(String)
-
-        /// Retrieving the Quick Connect code failed.
-        ///
-        /// Only thrown when incorrect/incomplete expected data
-        /// is returned from the server.
         case retrievingCodeFailed
-
-        var localizedError: String {
-            switch self {
-            case .maxPollingHit:
-                "Max polling hit"
-            case let .other(message):
-                message
-            case .retrievingCodeFailed:
-                "Retrieving code failed"
-            }
-        }
     }
-
-    /// The current state of the authorization flow.
-    @Published
-    public private(set) var state: State = .idle
 
     private let client: JellyfinClient
-    private let pollInterval: Int
-    private let maxPolls: Int
 
-    private var mainTask: Task<Void, Never>?
-
-    /// Creates a manager for performing a Quick Connect authorization flow.
-    ///
-    /// - Parameters:
-    ///   - client: The `JellyfinClient` to perform Quick Connect authorization with.
-    ///   - pollInterval: The polling interval, in seconds, while in the `polling` state.
-    ///   - maxPolls: The maximum number of polls while in the `polling` state. Hitting
-    ///               this amount of polls will throw a `maxPollingHit` error state.
-    ///
-    /// - Precondition: `pollInterval > 0`
-    /// - Precondition: `maxPolls > 0`
-    public init(
-        client: JellyfinClient,
-        pollInterval: Int = 5,
-        maxPolls: Int = 200
-    ) {
-        precondition(pollInterval > 0, "Polling interval must be at least one second")
-        precondition(maxPolls > 0, "Maximum polling must be positive")
-
+    init(client: JellyfinClient) {
         self.client = client
-        self.pollInterval = pollInterval
-        self.maxPolls = maxPolls
     }
 
-    /// Starts the Quick Connect authorization flow.
+    /// Starts a Quick Connect authorization flow when iterated.
     ///
-    /// - Important: Make sure to subscribe or await for `state` changes
-    ///              prior to starting Quick Connect.
-    @MainActor
-    public func start() {
-        guard state == .idle else { return }
+    /// - Parameters:
+    ///   - poll: Poll interval in seconds
+    ///   - max: Maximum number of polls
+    ///   - signIn: Automatically sign in with the retrieved secret when authenticated using `JellyfinClient.signIn(quickConnectSecret:)`
+    public func connect(
+        poll: Int = 5,
+        max: Int = 200,
+        signIn: Bool = false
+    ) -> AsyncThrowingStream<Event, Error> {
 
-        mainTask = Task {
-            await run()
+        precondition(poll > 0, "Polling interval must be at least one second")
+        precondition(max > 0, "Maximum polling must be positive")
+
+        return AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    try await run(poll: poll, max: max, signIn: signIn) { state in
+                        continuation.yield(state)
+                    }
+                    continuation.finish()
+                } catch is CancellationError {
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
         }
     }
 
-    /// Stops the current Quick Connect authorization flow.
-    @MainActor
-    public func stop() {
-        mainTask?.cancel()
-        state = .idle
-    }
+    private func run(
+        poll: Int,
+        max: Int,
+        signIn: Bool,
+        yield: (Event) -> Void
+    ) async throws {
 
-    private func run() async {
-        do {
-            await MainActor.run {
-                state = .retrievingCode
-            }
+        let (secret, code) = try await retrieveSecretAndCode()
 
-            let (secret, code) = try await retrieveSecretAndCode()
+        yield(.polling(code: code))
 
-            await MainActor.run {
-                self.state = .polling(code: code)
-            }
+        let authorizedSecret = try await pollForAuthorization(secret: secret, interval: poll, max: max)
 
-            let authorizedSecret = try await poll(secret: secret)
+        yield(.authenticated(secret: authorizedSecret))
 
-            await MainActor.run {
-                state = .authenticated(secret: authorizedSecret)
-            }
-        } catch let error as QuickConnectError {
-            await MainActor.run {
-                state = .error(error)
-            }
-        } catch is CancellationError {
-            // Task was cancelled, not an issue
-        } catch {
-            await MainActor.run {
-                state = .error(.other(error.localizedDescription))
-            }
+        if signIn {
+            try await client.signIn(quickConnectSecret: authorizedSecret)
         }
     }
 
     private func retrieveSecretAndCode() async throws -> (secret: String, code: String) {
 
-        let initiatePath = Paths.initiateQuickConnect
-        let response = try await client.send(initiatePath)
+        let request = Paths.initiateQuickConnect
+        let response = try await client.send(request)
 
         guard let secret = response.value.secret,
               let code = response.value.code
@@ -162,16 +113,18 @@ public final class QuickConnect: ObservableObject, @unchecked Sendable {
         return (secret, code)
     }
 
-    /// Note: `Task.sleep` doesn't guarantee actual time == given time, but
-    ///       variance is fairly tight and exact time doesn't matter.
-    private func poll(secret: String) async throws -> String {
+    private func pollForAuthorization(
+        secret: String,
+        interval: Int,
+        max: Int
+    ) async throws -> String {
 
-        for _ in 0 ..< maxPolls {
+        for _ in 0 ..< max {
             if let authSecret = try await checkAuthorization(secret: secret) {
                 return authSecret
             }
 
-            try await Task.sleep(nanoseconds: UInt64(1_000_000_000 * pollInterval))
+            try await Task.sleep(for: .seconds(interval))
         }
 
         throw QuickConnectError.maxPollingHit
@@ -182,9 +135,7 @@ public final class QuickConnect: ObservableObject, @unchecked Sendable {
         let request = Paths.getQuickConnectState(secret: secret)
         let response = try await client.send(request)
 
-        let isAuthenticated = response.value.isAuthenticated ?? false
-
-        guard isAuthenticated, let authorizedSecret = response.value.secret else { return nil }
+        guard response.value.isAuthenticated == true, let authorizedSecret = response.value.secret else { return nil }
 
         return authorizedSecret
     }

--- a/Tools/Package.resolved
+++ b/Tools/Package.resolved
@@ -1,0 +1,33 @@
+{
+  "originHash" : "1c33b23ece9cf72b7f43d28453ebe341a7e89839425be1e82b769762eae0728d",
+  "pins" : [
+    {
+      "identity" : "get",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kean/Get",
+      "state" : {
+        "revision" : "31249885da1052872e0ac91a2943f62567c0d96d",
+        "version" : "2.2.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "urlqueryencoder",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/CreateAPI/URLQueryEncoder",
+      "state" : {
+        "revision" : "4ce950479707ea109f229d7230ec074a133b15d7",
+        "version" : "0.2.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Tools/Package.swift
+++ b/Tools/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version:6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "Tools",
+    platforms: [
+        .macOS(.v13),
+    ],
+    products: [
+        .executable(name: "tools", targets: ["Tools"]),
+    ],
+    dependencies: [
+        .package(path: ".."),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.7.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "Tools",
+            dependencies: [
+                .product(name: "JellyfinAPI", package: "jellyfin-sdk-swift"),
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ]
+        ),
+    ]
+)

--- a/Tools/Sources/Tools/main.swift
+++ b/Tools/Sources/Tools/main.swift
@@ -45,19 +45,19 @@ struct QuickConnect: AsyncParsableCommand {
 
         for try await state in client.quickConnect.connect(
             poll: poll,
-            max: max,
-            signIn: signIn
+            max: max
         ) {
             switch state {
             case let .polling(code):
                 print("Code: \(code)")
             case let .authenticated(secret):
                 print("Authenticated with secret: \(secret)")
-            }
-        }
 
-        if signIn {
-            print("JellyfinClient signed in with token: \(client.accessToken ?? "<missing>")")
+                if signIn {
+                    try await client.signIn(quickConnectSecret: secret)
+                    print("Signed in with token: \(client.accessToken ?? "<missing>")")
+                }
+            }
         }
     }
 }

--- a/Tools/Sources/Tools/main.swift
+++ b/Tools/Sources/Tools/main.swift
@@ -1,0 +1,109 @@
+//
+// jellyfin-sdk-swift is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2026 Jellyfin & Jellyfin Contributors
+//
+
+import ArgumentParser
+import Foundation
+import JellyfinAPI
+
+@main
+struct JellyfinTools: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "tools",
+        abstract: "Tools for testing JellyfinAPI features",
+        subcommands: [
+            QuickConnect.self,
+            SignIn.self,
+        ]
+    )
+}
+
+struct QuickConnect: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "quickconnect",
+        abstract: "Perform a Quick Connect authentication request"
+    )
+
+    @Option(help: "Jellyfin server URL")
+    var server: String
+
+    @Option(help: "Polling interval in seconds")
+    var poll = 5
+
+    @Option(help: "Maximum poll count")
+    var max = 200
+
+    @Flag(help: "Sign in with the authenticated Quick Connect secret and print the access token")
+    var signIn = false
+
+    func run() async throws {
+        let client = try JellyfinClient.make(server: server)
+
+        for try await state in client.quickConnect.connect(
+            poll: poll,
+            max: max,
+            signIn: signIn
+        ) {
+            switch state {
+            case let .polling(code):
+                print("Code: \(code)")
+            case let .authenticated(secret):
+                print("Authenticated with secret: \(secret)")
+            }
+        }
+
+        if signIn {
+            print("JellyfinClient signed in with token: \(client.accessToken ?? "<missing>")")
+        }
+    }
+}
+
+struct SignIn: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "signin",
+        abstract: "Sign in with username and password"
+    )
+
+    @Option(help: "Jellyfin server URL")
+    var server: String
+
+    @Option(help: "Username")
+    var username: String
+
+    @Option(help: "Password")
+    var password: String
+
+    func run() async throws {
+        let client = try JellyfinClient.make(server: server)
+        let result = try await client.signIn(username: username, password: password)
+
+        guard let accessToken = result.accessToken else {
+            throw ValidationError("No access token returned")
+        }
+
+        print("Signed in with access token: \(accessToken)")
+    }
+}
+
+extension JellyfinClient {
+
+    static func make(server: String) throws -> JellyfinClient {
+        guard let url = URL(string: server), url.scheme != nil else {
+            throw ValidationError("Invalid server URL: \(server)")
+        }
+
+        return JellyfinClient(
+            configuration: .init(
+                url: url,
+                client: "JellyfinAPI Tools",
+                deviceName: Host.current().localizedName ?? "Jellyfin Tools",
+                deviceID: "jellyfin-sdk-swift-tools",
+                version: "1"
+            )
+        )
+    }
+}


### PR DESCRIPTION
- Update minimum versions
- Refactor `QuickConnect` to just a stream
- Add `JellyfinClient.url(with:)` and `JellyfinClient.url(path:)`