### PR TITLE
Fix url function produced invalid url

### DIFF
--- a/Sources/JellyfinClient.swift
+++ b/Sources/JellyfinClient.swift
@@ -254,6 +254,6 @@ public extension JellyfinClient {
 
     /// Creates a URL against the current server with the given path.
     func url(path: String) -> URL {
-        configuration.url.appending(component: path.trimmingPrefix(while: { $0 == "/" }))
+        configuration.url.appending(path: path.trimmingPrefix(while: { $0 == "/" }))
     }
 }


### PR DESCRIPTION
The `func url(with request: Request<some Any>, queryAPIKey: Bool = false) -> URL?` and `func url(path: String) -> URL` functions were producing an invalid url with percent encoded path, which results in status 404.

Before:
https://demo.jellyfin.org/stable/Audio%2F90b750a2cec4eb338c0dab3b40b8bb13%2Funiversal?container=opus,webm%7Copus,mp3,aac,m4a%7Caac,m4a%7Calac,m4b%7Caac,flac,webma,webm%7Cwebma,wav,ogg&transcodingProtocol=http&maxAudioBitDepth=999999999&api_key=a320e0be16b24ccb82db03e878275f82

After:
https://demo.jellyfin.org/stable/Audio/90b750a2cec4eb338c0dab3b40b8bb13/universal?container=opus,webm%7Copus,mp3,aac,m4a%7Caac,m4a%7Calac,m4b%7Caac,flac,webma,webm%7Cwebma,wav,ogg&transcodingProtocol=http&maxAudioBitDepth=999999999&api_key=2b9b65b06ce84dea80db17349122b14b