### PR TITLE
Fix URL paths with client

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -53,5 +53,9 @@ let package = Package(
             ],
             path: "Plugins/GenerateAPI"
         ),
+        .testTarget(
+            name: "JellyfinAPITests",
+            dependencies: ["JellyfinAPI"]
+        ),
     ]
 )

--- a/Sources/JellyfinClient.swift
+++ b/Sources/JellyfinClient.swift
@@ -254,21 +254,60 @@ public extension JellyfinClient {
     func url(with request: Request<some Any>, queryAPIKey: Bool = false) -> URL? {
 
         guard let path = request.url?.path else { return configuration.url }
-        let fullURL = url(path: path)
+        guard let fullURL = url(path: path) else { return nil }
         guard var components = URLComponents(url: fullURL, resolvingAgainstBaseURL: false) else { return nil }
 
-        components.queryItems = request.query?.map { URLQueryItem(name: $0.0, value: $0.1) } ?? []
+        var requestQueryItems = request.query?.map { URLQueryItem(name: $0.0, value: $0.1) } ?? []
 
         if queryAPIKey, let accessToken {
-            components.queryItems?.append(.init(name: "api_key", value: accessToken))
+            requestQueryItems.append(.init(name: "api_key", value: accessToken))
+        }
+
+        if !requestQueryItems.isEmpty {
+            var requestComponents = URLComponents()
+            requestComponents.queryItems = requestQueryItems
+            components
+                .percentEncodedQueryItems = (components.percentEncodedQueryItems ?? []) + (requestComponents.percentEncodedQueryItems ?? [])
         }
 
         return components.url ?? fullURL
     }
 
-    /// Creates a URL against the current server with the given path.
-    func url(path: String) -> URL {
-        configuration.url.appending(path: path.trimmingPrefix(while: { $0 == "/" }))
+    /// Creates a URL by appending the given path to the server URL.
+    ///
+    /// Existing path components in the server URL are preserved. Query items from the given
+    /// path are merged with any query items in the server URL.
+    ///
+    /// - Parameters:
+    ///   - path: the path to combine with the server URL
+    ///   - combine: A closure that takes the current and new query items for any
+    ///     duplicate query items.
+    func url(
+        path: String,
+        uniquingQueryItemsWith combine: (URLQueryItem, URLQueryItem) -> URLQueryItem = { x, _ in x }
+    ) -> URL? {
+        guard let pathComponents = URLComponents(string: path) else { return nil }
+
+        let relativePath = String(pathComponents.path.drop(while: { $0 == "/" }))
+        let url = configuration.url.appending(path: relativePath, directoryHint: .notDirectory)
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return nil }
+
+        if let pathQueryItems = pathComponents.percentEncodedQueryItems {
+            var queryItems = components.percentEncodedQueryItems ?? []
+            let filteredQueryItems = pathQueryItems.filter { !$0.name.isEmpty || $0.value != nil }
+
+            for pathQueryItem in filteredQueryItems {
+                if let index = queryItems.firstIndex(where: { $0.name == pathQueryItem.name }) {
+                    queryItems[index] = combine(queryItems[index], pathQueryItem)
+                } else {
+                    queryItems.append(pathQueryItem)
+                }
+            }
+
+            components.percentEncodedQueryItems = queryItems
+        }
+
+        return components.url
     }
 
     /// The URL used for web socket connections.

--- a/Tests/JellyfinAPITests/JellyfinClientURLTests.swift
+++ b/Tests/JellyfinAPITests/JellyfinClientURLTests.swift
@@ -1,0 +1,121 @@
+//
+// jellyfin-sdk-swift is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2026 Jellyfin & Jellyfin Contributors
+//
+
+import Foundation
+@testable import JellyfinAPI
+import Testing
+
+struct JellyfinClientURLTests {
+
+    @Test(arguments: [
+        ("https://example.com", "https://example.com/bar"),
+        ("https://example.com/foo", "https://example.com/foo/bar"),
+        ("https://example.com/foo/", "https://example.com/foo/bar"),
+        ("https://example.com:8096/foo/", "https://example.com:8096/foo/bar"),
+    ])
+    func urlPathAppendsToBaseURLPath(baseURL: String, expectedURL: String) throws {
+        let client = try makeClient(baseURL: baseURL)
+
+        #expect(try #require(client.url(path: "/bar")).absoluteString == expectedURL)
+    }
+
+    @Test(arguments: [
+        (
+            "https://example.com/foo?token=base",
+            "/bar/baz?foo=1",
+            "https://example.com/foo/bar/baz?token=base&foo=1"
+        ),
+        (
+            "https://sub.example.com/foo?token=base",
+            "/bar/baz?&foo=1",
+            "https://sub.example.com/foo/bar/baz?token=base&foo=1"
+        ),
+        (
+            "https://example.com/foo?token=base&mode=one",
+            "/bar/baz?mode=two",
+            "https://example.com/foo/bar/baz?token=base&mode=one"
+        ),
+        (
+            "https://sub.example.com/foo?token=a%2Bb",
+            "/bar/baz?qux=c%2Bd",
+            "https://sub.example.com/foo/bar/baz?token=a%2Bb&qux=c%2Bd"
+        ),
+        (
+            "https://example.com/foo?token=base",
+            "/bar/baz",
+            "https://example.com/foo/bar/baz?token=base"
+        ),
+        (
+            "https://example.com/foo?token=base",
+            "bar/baz",
+            "https://example.com/foo/bar/baz?token=base"
+        ),
+    ])
+    func urlPathCombinesBaseAndPathQueryItems(baseURL: String, path: String, expectedURL: String) throws {
+        let client = try makeClient(baseURL: baseURL)
+
+        #expect(try #require(client.url(path: path)).absoluteString == expectedURL)
+    }
+
+    @Test
+    func urlPathCanResolveQueryItemConflictsWithPathQueryItem() throws {
+        let client = try makeClient(baseURL: "https://example.com/foo?mode=one")
+        let url = try #require(client.url(path: "/bar?mode=two") { _, y in y })
+
+        #expect(url.absoluteString == "https://example.com/foo/bar?mode=two")
+    }
+
+    @Test
+    func urlWithRequestAppendsRequestPathToBasePath() throws {
+        let client = try makeClient(baseURL: "https://example.com/foo")
+        let url = try #require(client.url(with: Paths.getPublicSystemInfo))
+
+        #expect(url.absoluteString == "https://example.com/foo/System/Info/Public")
+    }
+
+    @Test
+    func urlWithRequestCombinesBaseAndRequestQueryItems() throws {
+        let client = try makeClient(baseURL: "https://example.com/foo?token=a%2Bb")
+        let url = try #require(client.url(with: Paths.getItem(itemID: "bar", userID: "baz")))
+
+        #expect(url.absoluteString == "https://example.com/foo/Items/bar?token=a%2Bb&userId=baz")
+    }
+
+    @Test
+    func urlWithRequestEncodesGeneratedQueryItems() throws {
+        let client = try makeClient(baseURL: "https://example.com/foo?token=base")
+        let request = Paths.getItems(parameters: .init(limit: 10, searchTerm: "foo bar"))
+        let url = try #require(client.url(with: request))
+
+        #expect(url.absoluteString == "https://example.com/foo/Items?token=base&limit=10&searchTerm=foo%20bar")
+    }
+
+    @Test
+    func urlWithRequestAppendsAPIKeyAfterBaseAndRequestQueryItems() throws {
+        let client = try makeClient(
+            baseURL: "https://example.com/foo?token=base",
+            accessToken: "token"
+        )
+        let url = try #require(client.url(with: Paths.getItem(itemID: "bar", userID: "baz"), queryAPIKey: true))
+
+        #expect(url.absoluteString == "https://example.com/foo/Items/bar?token=base&userId=baz&api_key=token")
+    }
+
+    private func makeClient(baseURL: String, accessToken: String? = nil) throws -> JellyfinClient {
+        try JellyfinClient(
+            configuration: .init(
+                url: #require(URL(string: baseURL)),
+                accessToken: accessToken,
+                client: "JellyfinClientURLTests",
+                deviceName: "Tests",
+                deviceID: "test-device-id",
+                version: "1.0"
+            )
+        )
+    }
+}


### PR DESCRIPTION
From https://github.com/jellyfin/Swiftfin/issues/2030

This was actually a bit tricky, mostly for resolving against pathed base URLs. The query item handling is just some future proofing, in the event they are ever necessary. This was tricky enough to start adding tests.